### PR TITLE
Move core tests from pyWATTS to pyWATTS-Pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**What is your feature request related to?**
+* Module request, or
+* Problem related
+
+**Please describe the module/problem**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+or 
+
+A clear and concise description of what the aim of the new module is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**What type of Feature Request**
+* Module request, or
+* Core enhancement

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+
+## Related Issues
+
+## Before submitting
+- [ ] Was this discussed/approved via a GitHub issue? (not for typos)
+- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
+- [ ] Did you make sure to update the documentation with your changes? (if necessary)
+- [ ] Did you write any new necessary tests? (not for typos and docs)
+- [ ] Did you verify new and existing tests pass locally with your changes?
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] Did you update the CHANGELOG
+
+## PR review
+Anyone in the community is free to review the PR once the tests have passed.
+
+- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
+- [ ] Check that all items from **Before submitting** are resolved
+- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
+- [ ] Add labels and milestones to the PR so it can be classified

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,13 +5,12 @@ name: Python application
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest torch
+        pip install flake8 pytest torch git+https://github.com/KIT-IAI/pyWATTS
         pip install .[dev]
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,47 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest torch
+        pip install .[dev]
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest
+#    - name: Integration tests
+#      run: |
+#        cd examples
+#        python example.py
+#        python example_keras.py
+#        python example_day_and_night.py
+#        python example_batch_execution.py
+#        python example_pytorch.py
+#        python example_transform_module.py

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest torch git+https://github.com/KIT-IAI/pyWATTS
+        pip install flake8 pytest torch git+https://github.com/KIT-IAI/pyWATTS@pipeline_extraction
         pip install .[dev]
     - name: Lint with flake8
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/pywatts_pipeline/core/callbacks/__init__.py
+++ b/pywatts_pipeline/core/callbacks/__init__.py
@@ -1,0 +1,1 @@
+from pywatts_pipeline.core.callbacks.base_callback import BaseCallback

--- a/pywatts_pipeline/core/callbacks/base_callback.py
+++ b/pywatts_pipeline/core/callbacks/base_callback.py
@@ -1,0 +1,66 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+import xarray as xr
+
+from pywatts_pipeline.core.util.filemanager import FileManager
+
+
+class BaseCallback(ABC):
+    """
+    Base callback class handling filemanager for all child classes.
+    All child classes need to implement at least the __call__ method.
+
+    :param ABC: Abstract Base Class
+    :type ABC: ABC
+    """
+
+    def __init__(self, use_filemanager: bool = True):
+        """
+        Initialisation method for base callback initialising the filemanager.
+
+        :param use_filemanager: If the pipeline should replace filemanager.
+        :type use_filemanager: bool, optional
+        """
+        self.filemanager = None
+        self.use_filemanager = use_filemanager
+
+    @abstractmethod
+    def __call__(self, data_dict: Dict[str, xr.DataArray]):
+        """
+        Abstract call method that need to be implemented by child classes.
+        So, callback objects can be called like simple functions
+        which are also allowed as callbacks.
+
+        :param data_dict: Dict of DataArrays as output from the pipeline step.
+        :type data_dict: Dict[str, xr.DataArray]
+        :raises NotImplementedError: Callbacks need to implement __call__ method.
+        """
+        raise NotImplementedError('Callbacks need to implement __call__ method!')
+
+    def set_filemanager(self, filemanager: FileManager):
+        """
+        Set or replace filemanager to change save location (e.g. for different runs)
+        if the user set the use_filemanager flag to True.
+
+        :param filemanager: [description]
+        :type filemanager: [type]
+        """
+        if self.use_filemanager:
+            self.filemanager = filemanager
+        else:
+            self.filemanager = None
+
+    def get_path(self, filename: str) -> str:
+        """
+        Get the full path to use as a save location for callback objects.
+
+        :param filename: Suggested name of the file (could be changed if already exist).
+        :type filename: str
+        :return: Full path to save the file to.
+        :rtype: str
+        """
+        if self.filemanager is None:
+            return filename
+        else:
+            return self.filemanager.get_path(filename)

--- a/pywatts_pipeline/core/condition/base_condition.py
+++ b/pywatts_pipeline/core/condition/base_condition.py
@@ -4,8 +4,8 @@ from typing import List
 
 import xarray as xr
 
-from pywatts.core.exceptions.step_creation_exception import StepCreationException
-from pywatts.core.step_information import StepInformation
+from pywatts_pipeline.core.exceptions.step_creation_exception import StepCreationException
+from pywatts_pipeline.core.step_information import StepInformation
 import pandas as pd
 
 class BaseCondition(ABC):

--- a/pywatts_pipeline/core/condition/base_condition.py
+++ b/pywatts_pipeline/core/condition/base_condition.py
@@ -5,7 +5,7 @@ from typing import List
 import xarray as xr
 
 from pywatts_pipeline.core.exceptions.step_creation_exception import StepCreationException
-from pywatts_pipeline.core.step_information import StepInformation
+from pywatts_pipeline.core.steps.step_information import StepInformation
 import pandas as pd
 
 class BaseCondition(ABC):

--- a/pywatts_pipeline/core/exceptions/__init__.py
+++ b/pywatts_pipeline/core/exceptions/__init__.py
@@ -1,7 +1,7 @@
-from pywatts.core.exceptions.input_not_available import InputNotAvailable
-from pywatts.core.exceptions.io_exceptions import IOException
-from pywatts.core.exceptions.kind_of_transform_does_not_exist_exception import KindOfTransform, \
+from pywatts_pipeline.core.exceptions.input_not_available import InputNotAvailable
+from pywatts_pipeline.core.exceptions.io_exceptions import IOException
+from pywatts_pipeline.core.exceptions.kind_of_transform_does_not_exist_exception import KindOfTransform, \
     KindOfTransformDoesNotExistException
-from pywatts.core.exceptions.not_fitted_exception import NotFittedException
-from pywatts.core.exceptions.util_exception import UtilException
-from pywatts.core.exceptions.wrong_parameter_exception import WrongParameterException
+from pywatts_pipeline.core.exceptions.not_fitted_exception import NotFittedException
+from pywatts_pipeline.core.exceptions.util_exception import UtilException
+from pywatts_pipeline.core.exceptions.wrong_parameter_exception import WrongParameterException

--- a/pywatts_pipeline/core/pipeline.py
+++ b/pywatts_pipeline/core/pipeline.py
@@ -131,7 +131,7 @@ class Pipeline(BaseTransformer):
         pass
 
     def test(self, data: Union[pd.DataFrame, xr.Dataset], summary: bool = True,
-             summary_formatter: SummaryFormatter = SummaryMarkdown(), refit=False, reset=False):
+             summary_formatter: SummaryFormatter = SummaryMarkdown(), refit=False, reset=True):
         """
         Executes all modules in the pipeline in the correct order. This method call only transform on every module
         if the ComputationMode is Default. I.e. if no computationMode is specified during the addition of the module to
@@ -191,8 +191,8 @@ class Pipeline(BaseTransformer):
 
         # TODO handle callbacks
         if summary:
-            self._create_summary(summary_formatter)
-            return result, summary
+            summary_data = self._create_summary(summary_formatter)
+            return result, summary_data
 
         return result
 

--- a/pywatts_pipeline/core/steps/either_or_step.py
+++ b/pywatts_pipeline/core/steps/either_or_step.py
@@ -15,8 +15,11 @@ class EitherOrStep(BaseStep):
         super().__init__(input_steps)
         self.name = "EitherOr"
 
-    def _compute(self, start, end, minimum_data):
-        input_data = self._get_input(start, end, minimum_data)
+    def _compute(self, start, end, minimum_data=None):
+        if minimum_data:
+            input_data = self._get_input(start, end, minimum_data)
+        else:
+            input_data = self._get_input(start, end)
         return self._transform(input_data)
 
     def _get_input(self, start, batch, minimum_data=(0, pd.Timedelta(0))):

--- a/pywatts_pipeline/core/steps/inverse_step.py
+++ b/pywatts_pipeline/core/steps/inverse_step.py
@@ -1,4 +1,4 @@
-from pywatts.core.exceptions.kind_of_transform_does_not_exist_exception import \
+from pywatts_pipeline.core.exceptions.kind_of_transform_does_not_exist_exception import \
     KindOfTransformDoesNotExistException, KindOfTransform
 from pywatts_pipeline.core.steps.step import Step
 

--- a/pywatts_pipeline/core/steps/pipeline_step.py
+++ b/pywatts_pipeline/core/steps/pipeline_step.py
@@ -39,7 +39,7 @@ class PipelineStep(Step):
         :type computation_mode: ComputationMode
         """
         self.current_run_setting = self.default_run_setting.update(run_setting=run_setting)
-        for step in self.module.id_to_step.values():
+        for step in self.module.steps:
             step.set_run_setting(run_setting)
         self.module.current_run_setting = self.current_run_setting
 
@@ -50,7 +50,7 @@ class PipelineStep(Step):
         """
         super().reset(keep_buffer=keep_buffer)
         self.module.result = {}
-        for step in self.module.id_to_step.values():
+        for step in self.module.steps:
             step.reset(keep_buffer=keep_buffer)
 
     def refit(self, start: pd.Timestamp, end: pd.Timestamp):

--- a/pywatts_pipeline/core/steps/step.py
+++ b/pywatts_pipeline/core/steps/step.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from pywatts.callbacks import BaseCallback
+from pywatts_pipeline.core.callbacks import BaseCallback
 from pywatts_pipeline.core.transformer.base import Base, BaseEstimator
 from pywatts_pipeline.core.condition.base_condition import BaseCondition
 from pywatts_pipeline.core.steps.base_step import BaseStep

--- a/pywatts_pipeline/core/steps/step_factory.py
+++ b/pywatts_pipeline/core/steps/step_factory.py
@@ -93,16 +93,14 @@ class StepFactory:
                         batch_size=batch_size, refit_conditions=refit_conditions, #retrain_batch=retrain_batch,
                         lag=lag)
 
-        step_id = pipeline.add(module=step,
+        pipeline.add(module=step,
                                input_ids=[step.id for step in input_steps.values()],
                                target_ids=[step.id for step in target_steps.values()])
-        step.id = step_id
-
         if len(target_steps) > 1:
             step.last = False
             for target in target_steps:
                 r_step = step.get_result_step(target)
-                r_id = pipeline.add(module=step, input_ids=[step_id])
+                r_id = pipeline.add(module=step)
                 r_step.id = r_id
 
         return StepInformation(step, pipeline)

--- a/pywatts_pipeline/core/steps/step_factory.py
+++ b/pywatts_pipeline/core/steps/step_factory.py
@@ -14,7 +14,7 @@ from pywatts_pipeline.core.steps.pipeline_step import PipelineStep
 from pywatts_pipeline.core.steps.probabilistic_step import ProbablisticStep
 from pywatts_pipeline.core.steps.step import Step
 from pywatts_pipeline.core.steps.step_information import StepInformation, SummaryInformation
-from pywatts.callbacks import BaseCallback
+from pywatts_pipeline.core.callbacks import BaseCallback
 from pywatts_pipeline.core.steps.summary_step import SummaryStep
 
 

--- a/pywatts_pipeline/core/summary/base_summary.py
+++ b/pywatts_pipeline/core/summary/base_summary.py
@@ -7,10 +7,10 @@ from typing import Dict, TYPE_CHECKING
 
 import xarray as xr
 
-from pywatts.core.base import Base
-from pywatts.core.filemanager import FileManager
-from pywatts.core.step_information import SummaryInformation
-from pywatts.core.summary_object import SummaryObject
+from pywatts_pipeline.core.base import Base
+from pywatts_pipeline.core.filemanager import FileManager
+from pywatts_pipeline.core.step_information import SummaryInformation
+from pywatts_pipeline.core.summary_object import SummaryObject
 
 if TYPE_CHECKING:
     pass

--- a/pywatts_pipeline/core/summary/base_summary.py
+++ b/pywatts_pipeline/core/summary/base_summary.py
@@ -7,10 +7,10 @@ from typing import Dict, TYPE_CHECKING
 
 import xarray as xr
 
-from pywatts_pipeline.core.base import Base
-from pywatts_pipeline.core.filemanager import FileManager
-from pywatts_pipeline.core.step_information import SummaryInformation
-from pywatts_pipeline.core.summary_object import SummaryObject
+from pywatts_pipeline.core.transformer.base import Base
+from pywatts_pipeline.core.util.filemanager import FileManager
+from pywatts_pipeline.core.steps.step_information import SummaryInformation
+from pywatts_pipeline.core.summary.summary_object import SummaryObject
 
 if TYPE_CHECKING:
     pass

--- a/pywatts_pipeline/core/summary/summary_step.py
+++ b/pywatts_pipeline/core/summary/summary_step.py
@@ -60,11 +60,11 @@ class SummaryStep(Step):
             "name": self.name,
         }
 
-    def get_summary(self, start, end) -> SummaryObject:
+    def get_summary(self, start) -> SummaryObject:
         """
         Calculates a summary for the input data.
         :return: The summary as markdown formatted string
         :rtype: Str
         """
-        input_data = self._get_input(start, end)
+        input_data = self._get_input(start)
         return self._transform(input_data)

--- a/pywatts_pipeline/core/summary/summary_step.py
+++ b/pywatts_pipeline/core/summary/summary_step.py
@@ -1,11 +1,11 @@
 import logging
 from typing import Dict
 
-from pywatts_pipeline.core.base_step import BaseStep
-from pywatts_pipeline.core.base_summary import BaseSummary
-from pywatts_pipeline.core.summary_object import SummaryObject
-from pywatts_pipeline.core.filemanager import FileManager
-from pywatts_pipeline.core.step import Step
+from pywatts_pipeline.core.steps.base_step import BaseStep
+from pywatts_pipeline.core.summary.base_summary import BaseSummary
+from pywatts_pipeline.core.summary.summary_object import SummaryObject
+from pywatts_pipeline.core.util.filemanager import FileManager
+from pywatts_pipeline.core.steps.step import Step
 
 logger = logging.getLogger(__name__)
 

--- a/pywatts_pipeline/core/summary/summary_step.py
+++ b/pywatts_pipeline/core/summary/summary_step.py
@@ -1,11 +1,11 @@
 import logging
 from typing import Dict
 
-from pywatts.core.base_step import BaseStep
-from pywatts.core.base_summary import BaseSummary
-from pywatts.core.summary_object import SummaryObject
-from pywatts.core.filemanager import FileManager
-from pywatts.core.step import Step
+from pywatts_pipeline.core.base_step import BaseStep
+from pywatts_pipeline.core.base_summary import BaseSummary
+from pywatts_pipeline.core.summary_object import SummaryObject
+from pywatts_pipeline.core.filemanager import FileManager
+from pywatts_pipeline.core.step import Step
 
 logger = logging.getLogger(__name__)
 

--- a/pywatts_pipeline/core/transformer/base.py
+++ b/pywatts_pipeline/core/transformer/base.py
@@ -11,7 +11,7 @@ from pywatts_pipeline.core.util.computation_mode import ComputationMode
 from pywatts_pipeline.core.exceptions.kind_of_transform_does_not_exist_exception import KindOfTransformDoesNotExistException, \
     KindOfTransform
 from pywatts_pipeline.core.util.filemanager import FileManager
-from pywatts.callbacks import BaseCallback
+from pywatts_pipeline.core.callbacks import BaseCallback
 
 if TYPE_CHECKING:
     from pywatts_pipeline.core.step_factory import StepInformation

--- a/pywatts_pipeline/core/transformer/base.py
+++ b/pywatts_pipeline/core/transformer/base.py
@@ -14,7 +14,7 @@ from pywatts_pipeline.core.util.filemanager import FileManager
 from pywatts_pipeline.core.callbacks import BaseCallback
 
 if TYPE_CHECKING:
-    from pywatts_pipeline.core.step_factory import StepInformation
+    from pywatts_pipeline.core.steps.step_factory import StepInformation
 
 
 class Base(ABC):

--- a/pywatts_pipeline/core/transformer/base.py
+++ b/pywatts_pipeline/core/transformer/base.py
@@ -14,7 +14,7 @@ from pywatts_pipeline.core.util.filemanager import FileManager
 from pywatts.callbacks import BaseCallback
 
 if TYPE_CHECKING:
-    from pywatts.core.step_factory import StepInformation
+    from pywatts_pipeline.core.step_factory import StepInformation
 
 
 class Base(ABC):

--- a/pywatts_pipeline/core/util/filemanager.py
+++ b/pywatts_pipeline/core/util/filemanager.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime
 
-from pywatts.core.exceptions.io_exceptions import IOException
+from pywatts_pipeline.core.exceptions.io_exceptions import IOException
 
 logger = logging.getLogger()
 

--- a/pywatts_pipeline/core/util/run_setting.py
+++ b/pywatts_pipeline/core/util/run_setting.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
-from pywatts.core.computation_mode import ComputationMode
-from pywatts.core.summary_formatter import SummaryFormatter, SummaryMarkdown
+from pywatts_pipeline.core.util.computation_mode import ComputationMode
+from pywatts_pipeline.core.summary.summary_formatter import SummaryFormatter, SummaryMarkdown
 
 
 class RunSetting:

--- a/pywatts_pipeline/utils/_workalendar_utils.py
+++ b/pywatts_pipeline/utils/_workalendar_utils.py
@@ -6,7 +6,7 @@ import workalendar.europe
 import workalendar.oceania
 import workalendar.usa
 
-from pywatts.core.exceptions.util_exception import UtilException
+from pywatts_pipeline.core.exceptions.util_exception import UtilException
 
 
 def _init_calendar(continent: str, country: str):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     version="0.3.0",
     packages=setuptools.find_packages(),
 
-    install_requires=['cloudpickle', 'xarray>=0.19', 'numpy', 'pandas', 'tabulate'],
+    install_requires=['cloudpickle', 'distlib', 'xarray>=0.19', 'numpy', 'pandas', 'tabulate'],
     extras_require={
         'dev': [
             "pytest",

--- a/tests/unit/core/test_either_or_step.py
+++ b/tests/unit/core/test_either_or_step.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import MagicMock
+
+from pywatts_pipeline.core.steps.either_or_step import EitherOrStep
+import xarray as xr
+import pandas as pd
+
+
+class TestEitherOrStep(unittest.TestCase):
+    def setUp(self) -> None:
+        self.step_one = MagicMock()
+        self.step_one.id = 1
+        self.step_two = MagicMock()
+        self.result_mock_step_2 = MagicMock()
+        self.result_mock_step_1 = MagicMock()
+        time = pd.date_range('2000-01-01', freq='24H', periods=7)
+
+        self.da2 = xr.DataArray([[2, 0], [3, 2], [4, 3], [5, 4], [6, 5], [7, 6], [8, 7]],
+                                dims=["time", "horizon"], coords={"time": time, "horizon": [0, 1]})
+        self.da1 = xr.DataArray([[5, 5], [5, 5], [4, 5], [5, 4], [6, 5], [7, 6], [8, 7]],
+                                dims=["time", "horizon"], coords={"time": time, "horizon": [0, 1]})
+        self.step_two.get_result.return_value = self.da2
+        self.step_one.get_result.return_value = self.da1
+        self.step_two.id = 2
+
+    def tearDown(self) -> None:
+        self.step_two = None
+        self.step_one = None
+
+    def test_transform(self):
+        self.step_one.get_result.return_value = None
+        step = EitherOrStep({"option1": self.step_one, "option2": self.step_two})
+        step.get_result(None, None)
+        xr.testing.assert_equal(step.buffer["EitherOr"], self.da2)
+
+    def test_load(self):
+        params = {
+            "target_ids": {},
+            "input_ids": {2: "stepTwo", 1: "stepOne"},
+            'default_run_setting': {'computation_mode': 4},
+            "id": -1,
+            "module": "pywatts_pipeline.core.steps.either_or_step",
+            "class": "EitherOrStep",
+            "name": "EitherOrStep",
+            "last": False
+        }
+        step = EitherOrStep.load(params, {"stepOne": self.step_one, "stepTwo": self.step_two}, None, None, None)
+        json = step.get_json("file")
+        self.assertEqual(params, json)

--- a/tests/unit/core/test_filemanager.py
+++ b/tests/unit/core/test_filemanager.py
@@ -1,0 +1,86 @@
+import unittest
+from datetime import datetime
+from unittest.mock import patch, call
+
+from pywatts_pipeline.core.exceptions.io_exceptions import IOException
+from pywatts_pipeline.core.util.filemanager import FileManager
+
+
+class TestFilemanager(unittest.TestCase):
+
+    @patch("pywatts_pipeline.core.util.filemanager.datetime")
+    @patch("pywatts_pipeline.core.util.filemanager.os")
+    def test_get_path(self, os_mock, datetime_mock):
+        datetime_mock.now.return_value = datetime(2442, 12, 24, 1, 2, 3)
+        os_mock.path.join.side_effect = ["testpath/2442_12_24_01_02_03",
+                                         "testpath/2442_12_24_01_02_03/my_result",
+                                         "testpath/2442_12_24_01_02_03/my_result/result.csv"]
+
+        self.filemanager = FileManager("testpath")
+
+        os_mock.path.isfile.return_value = False
+        os_mock.path.split.return_value = ("", "result.csv")
+
+        filepath = self.filemanager.get_path("result.csv", "my_result")
+
+        join_calls = [call("testpath", "2442_12_24_01_02_03"),
+                      call("testpath/2442_12_24_01_02_03", "my_result"),
+                      call("testpath/2442_12_24_01_02_03/my_result", "result.csv")
+                      ]
+        os_mock.path.join.assert_has_calls(join_calls)
+        os_mock.path.split.assert_called_once_with("result.csv")
+
+        self.assertEqual(filepath, "testpath/2442_12_24_01_02_03/my_result/result.csv")
+
+    @patch("pywatts_pipeline.core.util.filemanager.datetime")
+    @patch("pywatts_pipeline.core.util.filemanager.os")
+    def test_get_path_filename_with_path(self, os_mock, datetime_mock):
+        datetime_mock.now.return_value = datetime(2442, 12, 24, 1, 2, 3)
+        os_mock.path.join.side_effect = ["testpath/2442_12_24_01_02_03",
+                                         "testpath/2442_12_24_01_02_03/my_result",
+                                         "testpath/2442_12_24_01_02_03/my_result/result.csv"]
+
+        self.filemanager = FileManager("testpath")
+
+        os_mock.path.isfile.return_value = False
+        os_mock.path.split.return_value = ("", "result.csv")
+
+        filepath = self.filemanager.get_path("path/result.csv", "my_result")
+
+        self.assertEqual(filepath, "testpath/2442_12_24_01_02_03/my_result/result.csv")
+
+    @patch("pywatts_pipeline.core.util.filemanager.datetime")
+    @patch("pywatts_pipeline.core.util.filemanager.os")
+    def test_not_allowed_filetype(self, os_mock, datetime_mock):
+        datetime_mock.now.return_value = datetime(2442, 12, 24, 1, 2, 3)
+        os_mock.path.join.side_effect = ["testpath/2442_12_24_01_02_03"]
+
+        self.filemanager = FileManager("testpath")
+
+        os_mock.path.isfile.return_value = False
+        os_mock.path.split.return_value = ("", "result.test")
+        with self.assertRaises(IOException) as cm:
+            self.filemanager.get_path("result.test")
+        self.assertEqual(cm.exception.args,
+                         ("test is not an allowed file type. Allowed types are ['png', 'csv', 'xlsx', "
+                          "'pickle', 'tex', 'json', 'h5', 'pt', 'md'].",))
+
+    @patch("pywatts_pipeline.core.util.filemanager.logger")
+    @patch("pywatts_pipeline.core.util.filemanager.datetime")
+    @patch("pywatts_pipeline.core.util.filemanager.os")
+    def test_duplicate_filename(self, os_mock, datetime_mock, logger_mock):
+        datetime_mock.now.return_value = datetime(2442, 12, 24, 1, 2, 3)
+        os_mock.path.join.side_effect = ["testpath/2442_12_24_01_02_03",
+                                         "testpath/2442_12_24_01_02_03/my_result",
+                                         "testpath/2442_12_24_01_02_03/my_result/result.csv"]
+
+        os_mock.path.splitext.return_value = ("testpath/2442_12_24_01_02_03/my_result/result", "csv")
+
+        self.filemanager = FileManager("testpath")
+
+        os_mock.path.isfile.return_value = True
+        os_mock.path.split.return_value = ("", "result.csv")
+        result = self.filemanager.get_path("result.csv")
+        self.assertEqual(result, 'testpath/2442_12_24_01_02_03/my_result/result_1.csv')
+        logger_mock.info.assert_called_with('File %s already exists. We appended %s to the name',
+                                            'testpath/2442_12_24_01_02_03/my_result', 1)

--- a/tests/unit/core/test_inverse_step.py
+++ b/tests/unit/core/test_inverse_step.py
@@ -14,15 +14,18 @@ class TestInverseTransform(unittest.TestCase):
     def setUp(self) -> None:
         self.inverse_module = MagicMock()
         self.input_step = MagicMock()
-        time = pd.date_range('2000-01-01', freq='24H', periods=7)
+
+        time = pd.date_range("2000-01-01", freq="24H", periods=7)
+        da = xr.DataArray(
+            [[2, 0], [3, 2], [4, 3], [5, 4], [6, 5], [7, 6], [8, 7]],
+            dims=["time", "horizon"], coords={"time": time, "horizon": [0, 1]})
+        self.input_step.get_result.return_value = da
 
         self.inverse_module.inverse_transform.return_value = xr.DataArray(
             [[5, 5], [5, 5], [4, 5], [5, 4], [6, 5], [7, 6], [8, 7]],
             dims=["time", "horizon"], coords={"time": time, "horizon": [0, 1]})
         self.input_step._should_stop.return_value = False
         self.inverse_step = InverseStep(self.inverse_module, {"input": self.input_step}, file_manager=MagicMock())
-        self.inverse_step_result = MagicMock()
-        self.input_step.get_result.return_value = self.inverse_step_result
 
     def tearDown(self) -> None:
         self.inverse_module = None
@@ -32,20 +35,17 @@ class TestInverseTransform(unittest.TestCase):
     def test_get_result(self, *args):
         # This test checks if the get_result methods works corerctly, i.e. if it returns the correct result of the step and
         # calculate it if necessary.
-        time = pd.date_range('2000-01-01', freq='24H', periods=7)
-        da = xr.DataArray([[2, 0], [3, 2], [4, 3], [5, 4], [6, 5], [7, 6], [8, 7]],
-                                dims=["time", "horizon"], coords={"time": time, "horizon": [0, 1]})
-        self.input_step.get_result.return_value = da
         self.inverse_step.get_result(pd.Timestamp("2000.01.01"), None)
         self.inverse_module.inverse_transform.assert_called_once()
         xr.testing.assert_equal(self.inverse_module.inverse_transform.call_args[1]["input"],
-                                da)
+                                self.input_step.get_result.return_value)
 
     def test_get_result_stop(self):
         self.input_step.get_result.return_value = None
         self.inverse_step.get_result(pd.Timestamp("2000.01.01"), None)
 
         self.inverse_module.inverse_transform.assert_not_called()
+        # TODO: None is passed as minimum_data which causes an error at step.py:218
         self.assertTrue(self.inverse_step._should_stop(None, None))
 
     def test_transform_no_inverse_method(self):

--- a/tests/unit/core/test_inverse_step.py
+++ b/tests/unit/core/test_inverse_step.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock
+
+from pywatts_pipeline.core.exceptions.kind_of_transform_does_not_exist_exception import \
+    KindOfTransformDoesNotExistException, \
+    KindOfTransform
+from pywatts_pipeline.core.steps.inverse_step import InverseStep
+import pandas as pd
+import xarray as xr
+
+
+class TestInverseTransform(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.inverse_module = MagicMock()
+        self.input_step = MagicMock()
+        time = pd.date_range('2000-01-01', freq='24H', periods=7)
+
+        self.inverse_module.inverse_transform.return_value = xr.DataArray(
+            [[5, 5], [5, 5], [4, 5], [5, 4], [6, 5], [7, 6], [8, 7]],
+            dims=["time", "horizon"], coords={"time": time, "horizon": [0, 1]})
+        self.input_step._should_stop.return_value = False
+        self.inverse_step = InverseStep(self.inverse_module, {"input": self.input_step}, file_manager=MagicMock())
+        self.inverse_step_result = MagicMock()
+        self.input_step.get_result.return_value = self.inverse_step_result
+
+    def tearDown(self) -> None:
+        self.inverse_module = None
+        self.input_step = None
+        self.inverse_step = None
+
+    def test_get_result(self):
+        # This test checks if the get_result methods works corerctly, i.e. if it returns the correct result of the step and
+        # calculate it if necessary.
+        self.inverse_step.get_result(pd.Timestamp("2000.01.01"), None)
+        self.inverse_module.inverse_transform.assert_called_once_with(input=self.input_step.get_result())
+
+    def test_get_result_stop(self):
+        self.input_step.get_result.return_value = None
+        self.inverse_step.get_result(pd.Timestamp("2000.01.01"), None)
+
+        self.inverse_module.inverse_transform.assert_not_called()
+        self.assertTrue(self.inverse_step._should_stop(None, None))
+
+    def test_transform_no_inverse_method(self):
+        self.inverse_module.has_inverse_transform = False
+        self.inverse_module.name = "Magic"
+
+        with self.assertRaises(KindOfTransformDoesNotExistException) as context:
+            self.inverse_step.get_result(None, None)
+        self.assertEqual(f"The module Magic has no inverse transform", context.exception.message)
+        self.assertEqual(KindOfTransform.INVERSE_TRANSFORM, context.exception.method)
+
+        self.inverse_module.inverse_transform.assert_not_called()

--- a/tests/unit/core/test_inverse_step.py
+++ b/tests/unit/core/test_inverse_step.py
@@ -46,7 +46,7 @@ class TestInverseTransform(unittest.TestCase):
 
         self.inverse_module.inverse_transform.assert_not_called()
         # TODO: None is passed as minimum_data which causes an error at step.py:218
-        self.assertTrue(self.inverse_step._should_stop(None, None))
+        self.assertTrue(self.inverse_step._should_stop(None, (0, pd.Timedelta("1h"))))
 
     def test_transform_no_inverse_method(self):
         self.inverse_module.has_inverse_transform = False

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -1,0 +1,634 @@
+import os
+import unittest
+from unittest.mock import mock_open, patch, call, MagicMock
+
+import pandas as pd
+import xarray as xr
+from sklearn.linear_model import LinearRegression
+from sklearn.preprocessing import StandardScaler
+
+from pywatts_pipeline.core.util.computation_mode import ComputationMode
+from pywatts_pipeline.core.pipeline import Pipeline
+from pywatts_pipeline.core.steps.start_step import StartStep
+from pywatts_pipeline.core.steps.step import Step
+from pywatts_pipeline.core.util.run_setting import RunSetting
+from pywatts.modules import MissingValueDetector, SKLearnWrapper
+from pywatts.summaries import RMSE
+
+pipeline_json = {'id': 1,
+                 'name': 'Pipeline',
+                 'modules': [{'class': 'SKLearnWrapper',
+                              'is_fitted': False,
+                              'module': 'pywatts.modules.wrappers.sklearn_wrapper',
+                              'name': 'StandardScaler',
+                              'sklearn_module': os.path.join('test_pipeline', 'StandardScaler.pickle'),
+                              'targets': []},
+                             {'class': 'SKLearnWrapper',
+                              'is_fitted': False,
+                              'module': 'pywatts.modules.wrappers.sklearn_wrapper',
+                              'name': 'LinearRegression',
+                              'sklearn_module': os.path.join('test_pipeline', 'LinearRegression.pickle'),
+                              'targets': []}],
+                 'steps': [{'class': 'StartStep',
+                            'default_run_setting': {'computation_mode': 4},
+                            'id': 1,
+                            'index': 'input',
+                            'input_ids': {},
+                            'last': False,
+                            'module': 'pywatts.core.start_step',
+                            'name': 'input',
+                            'target_ids': {}},
+                           {'batch_size': None,
+                            'callbacks': [],
+                            'class': 'Step',
+                            'default_run_setting': {'computation_mode': 4},
+                            'condition': None,
+                            'id': 2,
+                            'input_ids': {1: 'input'},
+                            'last': False,
+                            'module': 'pywatts.core.step',
+                            'module_id': 0,
+                            'name': 'StandardScaler',
+                            'target_ids': {},
+                            'refit_conditions': []},
+                           {'batch_size': None,
+                            'callbacks': [],
+                            'class': 'Step',
+                            'default_run_setting': {'computation_mode': 4},
+                            'condition': None,
+                            'id': 3,
+                            'input_ids': {2: 'x'},
+                            'last': True,
+                            'module': 'pywatts.core.step',
+                            'module_id': 1,
+                            'name': 'LinearRegression',
+                            'target_ids': {},
+                            'refit_conditions': []}],
+                 'version': 1}
+
+
+class TestPipeline(unittest.TestCase):
+
+    @patch("pywatts.core.pipeline.FileManager")
+    def setUp(self, fm_mock) -> None:
+        self.fm_mock = fm_mock()
+        self.pipeline = Pipeline()
+
+    def tearDown(self) -> None:
+        self.pipeline = None
+
+    def test_add_input_as_positional(self):
+        # Should fail with an better error message
+        SKLearnWrapper(LinearRegression())(x=self.pipeline["input"])
+
+    def test_add_only_module(self):
+        SKLearnWrapper(LinearRegression())(x=self.pipeline["input"])
+        # nodes 1 plus startstep
+        self.assertEqual(len(self.pipeline.id_to_step), 2)
+
+    def test_add_module_which_is_not_in_a_list(self):
+        wrapper = SKLearnWrapper(LinearRegression())(input=self.pipeline["input"])
+        SKLearnWrapper(LinearRegression())(x=wrapper)
+        # nodes 1 plus startstep
+        self.assertEqual(len(self.pipeline.id_to_step), 3)
+
+    def test_add_pipeline_without_index(self):
+        # This should raise an exception since pipeline might get multiple columns in the input dataframe
+        with self.assertRaises(Exception) as context:
+            SKLearnWrapper(StandardScaler())(x=self.pipeline)  # This should fail
+        self.assertEqual(
+            "Adding a pipeline as input might be ambigious. Specifiy the desired column of your dataset by using pipeline[<column_name>]",
+            str(context.exception))
+
+    def test_add_module_with_inputs(self):
+        scaler1 = SKLearnWrapper(StandardScaler())(x=self.pipeline["x"])
+        scaler2 = SKLearnWrapper(StandardScaler())(x=self.pipeline["test1"])
+        SKLearnWrapper(LinearRegression())(input_1=scaler1, input_2=scaler2)
+
+        # Three modules plus start step and one collect step
+        self.assertEqual(5, len(self.pipeline.id_to_step))
+
+    def test_add_module_with_one_input_without_a_list(self):
+        scaler = SKLearnWrapper(StandardScaler())(input=self.pipeline["test"])
+        SKLearnWrapper(LinearRegression())(input=scaler)
+
+        # Three modules plus start step and one collect step
+        self.assertEqual(3, len(self.pipeline.id_to_step))
+
+    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts.core.pipeline.json')
+    @patch("builtins.open", new_callable=mock_open)
+    def test_to_folder(self, mock_file, json_mock, fm_mock):
+        scaler = SKLearnWrapper(StandardScaler())(input=self.pipeline["input"])
+        SKLearnWrapper(LinearRegression())(x=scaler)
+        fm_mock_object = MagicMock()
+        fm_mock.return_value = fm_mock_object
+        fm_mock_object.get_path.side_effect = [
+            os.path.join('test_pipeline', 'StandardScaler.pickle'),
+            os.path.join('test_pipeline', 'LinearRegression.pickle'),
+            os.path.join('test_pipeline', 'pipeline.json'),
+        ]
+
+        self.pipeline.to_folder("test_pipeline")
+
+        calls_open = [call(os.path.join('test_pipeline', 'StandardScaler.pickle'), 'wb'),
+                      call(os.path.join('test_pipeline', 'LinearRegression.pickle'), 'wb'),
+                      call(os.path.join('test_pipeline', 'pipeline.json'), 'w')]
+        mock_file.assert_has_calls(calls_open, any_order=True)
+        args, kwargs = json_mock.dump.call_args
+        assert kwargs["obj"]["id"] == pipeline_json["id"]
+        assert kwargs["obj"]["name"] == pipeline_json["name"]
+
+        assert kwargs["obj"]["modules"] == pipeline_json["modules"]
+        assert kwargs["obj"]["steps"] == pipeline_json["steps"]
+
+    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts.modules.sklearn_wrapper.cloudpickle')
+    @patch('pywatts.core.pipeline.json')
+    @patch("builtins.open", new_callable=mock_open)
+    @patch('pywatts.core.pipeline.os.path.isdir')
+    def test_from_folder(self, isdir_mock, mock_file, json_mock, pickle_mock, fm_mock):
+        scaler = StandardScaler()
+        linear_regression = LinearRegression()
+
+        isdir_mock.return_value = True
+        json_mock.load.return_value = pipeline_json
+
+        pickle_mock.load.side_effect = [scaler, linear_regression]
+
+        pipeline = Pipeline.from_folder("test_pipeline")
+        calls_open = [call(os.path.join("test_pipeline", "StandardScaler.pickle"), "rb"),
+                      call(os.path.join("test_pipeline", "LinearRegression.pickle"), "rb"),
+                      call(os.path.join("test_pipeline", "pipeline.json"), "r")]
+
+        mock_file.assert_has_calls(calls_open, any_order=True)
+
+        json_mock.load.assert_called_once()
+        assert pickle_mock.load.call_count == 2
+
+        isdir_mock.assert_called_once()
+        self.assertEqual(3, len(pipeline.id_to_step))
+
+    def test_module_naming_conflict(self):
+        # This test should check, that modules with the same name do not lead to an error
+        # What should this test?        
+        # self.fail()
+        pass
+
+    def test_add_with_target(self):
+        SKLearnWrapper(LinearRegression())(input=self.pipeline["input"], target=self.pipeline["target"])
+        self.assertEqual(3, len(self.pipeline.id_to_step))
+
+    def test_multiple_same_module(self):
+        reg_module = SKLearnWrapper(module=LinearRegression())
+        reg_one = reg_module(x=self.pipeline["test"], target=self.pipeline["target"])
+        reg_two = reg_module(x=self.pipeline["test2"], target=self.pipeline["target"])
+        detector = MissingValueDetector()
+        detector(dataset=reg_one)
+        detector(dataset=reg_two)
+
+        # Three start steps (test, test2, target), two regressors two detectors
+        self.assertEqual(7, len(self.pipeline.id_to_step))
+        modules = []
+        for element in self.pipeline.id_to_step.values():
+            if isinstance(element, Step) and not element.module in modules:
+                modules.append(element.module)
+        # One sklearn wrappers, one missing value detector
+        self.assertEqual(2, len(modules))
+
+        self.pipeline.train(
+            pd.DataFrame({"test": [1, 2, 2, 3, 4], "test2": [2, 2, 2, 2, 2], "target": [2, 2, 4, 4, -5]},
+                         index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=5))))
+
+    @patch('pywatts.core.pipeline.Pipeline._create_summary')
+    @patch('pywatts.core.pipeline.FileManager')
+    def test_add_pipeline_to_pipeline_and_train(self, fm_mock, create_summary_mock):
+        sub_pipeline = Pipeline()
+
+        detector = MissingValueDetector()
+
+        detector(dataset=sub_pipeline["regression"])
+
+        regressor = SKLearnWrapper(LinearRegression(), name="regression")(x=self.pipeline["test"],
+                                                                          target=self.pipeline["target"])
+        sub_pipeline(regression=regressor)
+
+        summary_formatter_mock = MagicMock()
+        self.pipeline.train(pd.DataFrame({"test": [24, 24], "target": [12, 24]}, index=pd.to_datetime(
+            ['2015-06-03 00:00:00', '2015-06-03 01:00:00'])), summary_formatter=summary_formatter_mock)
+
+        for step in self.pipeline.id_to_step.values():
+            assert step.current_run_setting.computation_mode == ComputationMode.FitTransform
+        assert 2 == create_summary_mock.call_count
+        create_summary_mock.assert_has_calls([call(summary_formatter_mock, None), call(summary_formatter_mock, None)], any_order=True)
+
+    @patch('pywatts.core.pipeline.FileManager')
+    def test_add_pipeline_to_pipeline_and_test(self, fm_mock):
+        # Add some steps to the pipeline
+
+        # Assert that the computation is set to fit_transform if the ComputationMode was default
+
+        step = MagicMock()
+        step.computation_mode = ComputationMode.Default
+        step.finished = False
+        time = pd.date_range('2000-01-01', freq='24H', periods=7)
+
+        ds = xr.Dataset({'foo': ('time', [2, 3, 4, 5, 6, 7, 8]), 'time': time})
+
+        subpipeline = Pipeline()
+        subpipeline.add(module=step)
+
+        # BUG: In step_factory.py -> create_step the file_manager of the pipeline is accessed
+        # and the pipeline is None... 
+        # subpipeline(self.pipeline)
+
+        # self.pipeline.test(ds)
+
+        # step.set_computation_mode.assert_called_once_with(ComputationMode.Transform)
+
+        # step.reset.assert_called_once()
+
+    @patch("pywatts.core.pipeline.FileManager")
+    @patch('pywatts.core.pipeline.json')
+    @patch("builtins.open", new_callable=mock_open)
+    def test_add_pipeline_to_pipeline_and_save(self, open_mock, json_mock, fm_mock):
+        sub_pipeline = Pipeline()
+
+        detector = MissingValueDetector()
+        detector(dataset=sub_pipeline["regressor"])
+
+        regressor = SKLearnWrapper(LinearRegression())(x=self.pipeline["test"])
+        sub_pipeline(regression=regressor)
+
+        self.pipeline.to_folder(path="path")
+
+        self.assertEqual(json_mock.dump.call_count, 2)
+
+    def create_summary_in_subpipelines(self):
+        assert False
+
+    @patch('pywatts.core.pipeline.FileManager')
+    def test__collect_batch_results_naming_conflict(self, fm_mock):
+        step_one = MagicMock()
+        step_one.name = "step"
+        step_two = MagicMock()
+        step_two.name = "step"
+        result_step_one = MagicMock()
+        result_step_two = MagicMock()
+        merged_result = {
+            "step": result_step_one,
+            "step_1": result_step_two
+        }
+
+        step_one.get_result.return_value = {"step": result_step_one}
+        step_two.get_result.return_value = {"step_1": result_step_two}
+
+        result = self.pipeline._collect_results([step_one, step_two])
+
+        # Assert that steps are correclty called.
+        step_one.get_result.assert_called_once_with(None, None, return_all=True)
+        step_two.get_result.assert_called_once_with(None, None, return_all=True)
+
+        # Assert return value is correct
+        self.assertEqual(merged_result, result)
+
+    @patch("pywatts.core.pipeline.FileManager")
+    def test_get_params(self, fm_mock):
+        result = Pipeline(batch=pd.Timedelta("1h")).get_params()
+        self.assertEqual(result, {
+            "batch": pd.Timedelta("1h")
+        })
+
+    def test_set_params(self):
+        self.pipeline.set_params(batch=pd.Timedelta("2h"))
+        self.assertEqual(self.pipeline.get_params(),
+                         {
+                             "batch": pd.Timedelta("2h")
+                         })
+
+    def test__collect_batch_results(self):
+        step_one = MagicMock()
+        step_one.name = "step_one"
+        step_two = MagicMock()
+        step_two.name = "step_two"
+        result_step_one = MagicMock()
+        result_step_two = MagicMock()
+        merged_result = {
+            "step_one": result_step_one,
+            "step_two": result_step_two
+        }
+
+        step_one.get_result.return_value = {"step_one": result_step_one}
+        step_two.get_result.return_value = {"step_two": result_step_two}
+
+        result = self.pipeline._collect_results([step_one, step_two])
+
+        # Assert that steps are correclty called.
+        step_one.get_result.assert_called_once_with(None, None, return_all=True)
+        step_two.get_result.assert_called_once_with(None, None, return_all=True)
+
+        # Assert return value is correct
+        self.assertEqual(merged_result, result)
+
+    @patch("pywatts.core.pipeline.FileManager")
+    @patch("pywatts.core.pipeline.xr.concat")
+    def test_batched_pipeline(self, concat_mock, fm_mock):
+        # Add some steps to the pipeline
+
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+
+        # Assert that the computation is set to fit_transform if the ComputationMode was default
+        first_step = MagicMock()
+        first_step.run_setting = RunSetting(ComputationMode.Default)
+        first_step.finished = False
+        first_step.further_elements.side_effect = [True, True, True, True, False]
+
+        first_step.get_result.return_value = {"one": da}
+        self.pipeline.set_params(pd.Timedelta("24h"))
+        self.pipeline.add(module=first_step)
+
+        data = pd.DataFrame({"test": [1, 2, 2, 3], "test2": [2, 2, 2, 2]},
+                            index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=4)))
+        self.pipeline.test(data)
+
+        first_step.set_run_setting.assert_called_once()
+        self.assertEqual(first_step.set_run_setting.call_args[0][0].computation_mode, ComputationMode.Transform)
+        calls = [
+            call(pd.Timestamp('2000-01-01 00:00:00', freq='24H'), pd.Timestamp('2000-01-02 00:00:00', freq='24H'),
+                 return_all=True),
+            call(pd.Timestamp('2000-01-02 00:00:00', freq='24H'), pd.Timestamp('2000-01-03 00:00:00', freq='24H'),
+                 return_all=True),
+            call(pd.Timestamp('2000-01-03 00:00:00', freq='24H'), pd.Timestamp('2000-01-04 00:00:00', freq='24H'),
+                 return_all=True),
+            call(pd.Timestamp('2000-01-04 00:00:00', freq='24H'), pd.Timestamp('2000-01-05 00:00:00', freq='24H'),
+                 return_all=True),
+        ]
+        first_step.get_result.assert_has_calls(calls, any_order=True)
+        self.assertEqual(concat_mock.call_count, 3)
+
+    @patch("pywatts.core.pipeline.FileManager")
+    @patch("pywatts.core.pipeline.xr.concat")
+    def test_batch_2H_transform(self, concat_mock, fm_mock):
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+        pipeline = Pipeline(batch=pd.Timedelta("2h"))
+        step_one = MagicMock()
+        step_one.get_result.return_value = {"step": da}
+        step_one.name = "step"
+        result_mock = MagicMock()
+        concat_mock.return_value = result_mock
+        pipeline.start_steps["foo"] = StartStep("foo"), None
+        pipeline.start_steps["foo"][0].last = False
+        step_one.further_elements.side_effect = [True, True, True, True, False]
+        pipeline.add(module=step_one, input_ids=[1])
+        pipeline.current_run_setting = RunSetting(computation_mode=ComputationMode.Transform)
+
+        result = pipeline.transform(foo=da)
+
+        self.assertEqual(concat_mock.call_count, 3)
+        self.assertEqual(step_one.get_result.call_count, 4)
+        self.assertEqual(step_one.further_elements.call_count, 5)
+        self.assertEqual({"step": result_mock}, result)
+
+    @patch('pywatts.core.pipeline.FileManager')
+    @patch("pywatts.core.pipeline._get_time_indexes", return_value=["time"])
+    def test_transform_pipeline(self, get_time_indexes_mock, fm_mock):
+        input_mock = MagicMock()
+        input_mock.indexes = {"time": ["20.12.2020"]}
+        step_two = MagicMock()
+        result_mock = MagicMock()
+        step_two.name = "mock"
+        step_two.get_result.return_value = {"mock": result_mock}
+        self.pipeline.add(module=step_two, input_ids=[1])
+        self.pipeline.current_run_setting = RunSetting(computation_mode=ComputationMode.Transform)
+
+        result = self.pipeline.transform(x=input_mock)
+
+        step_two.get_result.assert_called_once_with("20.12.2020", None, return_all=True)
+        get_time_indexes_mock.assert_called_once_with({"x": input_mock})
+        self.assertEqual({"mock": result_mock}, result)
+
+    @patch("pywatts.core.pipeline.FileManager")
+    @patch("pywatts.core.pipeline.Pipeline.from_folder")
+    def test_load(self, from_folder_mock, fm_mock):
+        created_pipeline = MagicMock()
+        from_folder_mock.return_value = created_pipeline
+        pipeline = Pipeline.load({'name': 'Pipeline',
+                                  'class': 'Pipeline',
+                                  'module': 'pywatts.core.pipeline',
+                                  'pipeline_path': 'save_path'})
+
+        from_folder_mock.assert_called_once_with("save_path")
+        self.assertEqual(created_pipeline, pipeline)
+
+    @patch("pywatts.core.pipeline.FileManager")
+    @patch("pywatts.core.pipeline.Pipeline.to_folder")
+    @patch("pywatts.core.pipeline.os")
+    def test_save(self, os_mock, to_folder_mock, fm_mock):
+        os_mock.path.join.return_value = "save_path"
+        os_mock.path.isdir.return_value = False
+        sub_pipeline = Pipeline(batch=pd.Timedelta("1h"))
+        detector = MissingValueDetector()
+        detector(dataset=sub_pipeline["test"])
+        fm_mock = MagicMock()
+        fm_mock.basic_path = "path_to_save"
+        result = sub_pipeline.save(fm_mock)
+
+        to_folder_mock.assert_called_once_with("save_path")
+        os_mock.path.join.assert_called_once_with("path_to_save", "Pipeline")
+        self.assertEqual({'name': 'Pipeline',
+                          'class': 'Pipeline',
+                          'module': 'pywatts.core.pipeline',
+                          'params': {'batch': '0 days 01:00:00'},
+                          'pipeline_path': 'save_path'}, result)
+
+    @patch("pywatts.core.pipeline.FileManager")
+    @patch("pywatts.core.pipeline.xr.concat")
+    def test_batch_1_transform(self, concat_mock, fm_mock):
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+        pipeline = Pipeline(batch=pd.Timedelta("1h"))
+        step_one = MagicMock()
+        step_one.get_result.return_value = {"step": da}
+        step_one.name = "step"
+        result_mock = MagicMock()
+        concat_mock.return_value = result_mock
+        pipeline.start_steps["foo"] = StartStep("foo"), None
+        pipeline.start_steps["foo"][0].last = False
+        step_one.further_elements.side_effect = [True, True, True, True, True, True, True, False]
+        pipeline.current_run_setting = RunSetting(computation_mode=ComputationMode.Transform)
+        pipeline.add(module=step_one, input_ids=[1])
+
+        result = pipeline.transform(foo=da)
+
+        self.assertEqual(concat_mock.call_count, 6)
+        self.assertEqual(step_one.get_result.call_count, 7)
+        self.assertEqual(step_one.further_elements.call_count, 8)
+        self.assertEqual({"step": result_mock}, result)
+
+    @patch('pywatts.core.pipeline.FileManager')
+    def test_test(self, fm_mock):
+        # Add some steps to the pipeline
+
+        # Assert that the computation is set to fit_transform if the ComputationMode was default
+        first_step = MagicMock()
+        first_step.computation_mode = ComputationMode.Default
+        first_step.finished = False
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+
+        first_step.get_result.return_value = {"first": da}
+        second_step = MagicMock()
+        second_step.computation_mode = ComputationMode.Train
+        second_step.finished = False
+        second_step.get_result.return_value = {"Second": da}
+
+        self.pipeline.add(module=first_step)
+        self.pipeline.add(module=second_step)
+
+        self.pipeline.test(pd.DataFrame({"test": [1, 2, 2, 3, 4], "test2": [2, 2, 2, 2, 2]},
+                                        index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=5))))
+
+        first_step.get_result.assert_called_once_with(pd.Timestamp('2000-01-01 00:00:00', freq='24H'), None,
+                                                      return_all=True)
+        second_step.get_result.assert_called_once_with(pd.Timestamp('2000-01-01 00:00:00', freq='24H'), None,
+                                                       return_all=True)
+
+        first_step.set_run_setting.assert_called_once()
+        self.assertEqual(first_step.set_run_setting.call_args[0][0].computation_mode, ComputationMode.Transform)
+        second_step.set_run_setting.assert_called_once()
+        self.assertEqual(second_step.set_run_setting.call_args[0][0].computation_mode, ComputationMode.Transform)
+
+        first_step.reset.assert_called_once()
+        second_step.reset.assert_called_once()
+
+    @patch('pywatts.core.pipeline.FileManager')
+    def test_train(self, fmmock):
+        # Add some steps to the pipeline
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+
+        # Assert that the computation is set to fit_transform if the ComputationMode was default
+        first_step = MagicMock()
+        first_step.computation_mode = ComputationMode.Default
+        first_step.finished = False
+        first_step.get_result.return_value = {"first": da}
+
+        second_step = MagicMock()
+        second_step.computation_mode = ComputationMode.Train
+        second_step.finished = False
+        second_step.get_result.return_value = {"second": da}
+
+        self.pipeline.add(module=first_step)
+        self.pipeline.add(module=second_step)
+
+        data = pd.DataFrame({"test": [1, 2, 2, 3, 4], "test2": [2, 2, 2, 2, 2]},
+                            index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=5)))
+        result, summary = self.pipeline.train(data, summary=True)
+
+        first_step.set_run_setting.assert_called_once()
+        self.assertEqual(first_step.set_run_setting.call_args[0][0].computation_mode, ComputationMode.FitTransform)
+        second_step.set_run_setting.assert_called_once()
+        self.assertEqual(second_step.set_run_setting.call_args[0][0].computation_mode, ComputationMode.FitTransform)
+
+        first_step.get_result.assert_called_once_with(pd.Timestamp('2000-01-01 00:00:00', freq='24H'), None,
+                                                      return_all=True)
+        second_step.get_result.assert_called_once_with(pd.Timestamp('2000-01-01 00:00:00', freq='24H'), None,
+                                                       return_all=True)
+
+        first_step.reset.assert_called_once()
+        second_step.reset.assert_called_once()
+        xr.testing.assert_equal(result["second"], da)
+
+    @patch('pywatts.core.pipeline.FileManager')
+    def test_train_return_no_summary(self, fmmock):
+        # Add some steps to the pipeline
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+
+        # Assert that the computation is set to fit_transform if the ComputationMode was default
+        first_step = MagicMock()
+        first_step.computation_mode = ComputationMode.Default
+        first_step.finished = False
+        first_step.get_result.return_value = {"first": da}
+
+        second_step = MagicMock()
+        second_step.computation_mode = ComputationMode.Train
+        second_step.finished = False
+        second_step.get_result.return_value = {"second": da}
+
+        self.pipeline.add(module=first_step)
+        self.pipeline.add(module=second_step)
+
+        data = pd.DataFrame({"test": [1, 2, 2, 3, 4], "test2": [2, 2, 2, 2, 2]},
+                            index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=5)))
+        result = self.pipeline.train(data, summary=False)
+
+        assert not isinstance(result, tuple)
+        xr.testing.assert_equal(result["second"], da)
+
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_horizon_greater_one_regression_inclusive_summary_file(self, open_mock):
+        lin_reg = LinearRegression()
+        self.fm_mock.get_path.return_value = "summary_path"
+
+        multi_regressor = SKLearnWrapper(lin_reg)(foo=self.pipeline["foo"], target=self.pipeline["target"],
+                                                  target2=self.pipeline["target2"])
+        RMSE()(y=self.pipeline["target"], prediction=multi_regressor["target"])
+
+        time = pd.date_range('2000-01-01', freq='24H', periods=5)
+
+        foo = xr.DataArray([1, 2, 3, 4, 5], dims=["time"], coords={'time': time})
+        target = xr.DataArray([[2, 3], [2, 4], [2, 5], [2, 6], [2, 7]], dims=["time", "horizon"],
+                              coords={'time': time, "horizon": [1, 2]})
+        target2 = xr.DataArray([3, 3, 3, 3, 3], dims=["time"], coords={'time': time})
+
+        ds = xr.Dataset({'foo': foo, "target": target, "target2": target2})
+
+        result, summary = self.pipeline.train(ds, summary=True)
+
+        self.assertTrue("Training Time" in summary)
+        self.assertTrue("RMSE" in summary)
+
+        self.fm_mock.get_path.assert_called_once_with("summary.md")
+        open_mock().__enter__.return_value.write.assert_called_once_with(summary)
+
+        self.assertTrue("target" in result.keys())
+
+    @patch('pywatts.core.pipeline.isinstance', return_value=True)
+    def test_refit(self, isinstance_mock):
+        first_step = MagicMock()
+        first_step.lag = pd.Timedelta("1d")
+
+        self.pipeline.add(module=first_step)
+        self.pipeline.refit(pd.Timestamp("2000.01.02"), pd.Timestamp("2022.01.02"))
+
+        first_step.refit.assert_called_once_with(pd.Timestamp("2000.01.01"), pd.Timestamp("2022.01.01"))
+
+    def test_online_with_filled_buffer(self):
+
+        time = pd.date_range('2000-01-01', freq='1D', periods=7)
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+        pipeline = Pipeline(batch=pd.Timedelta(days=1))
+        step_one = MagicMock()
+        step_one.get_result.return_value = {"step": da}
+
+        pipeline.start_steps["foo"] = StartStep("foo"), None
+        pipeline.start_steps["foo"][0].last = False
+        step_one.further_elements.side_effect = [True, True, True, True, False]
+        pipeline.add(module=step_one, input_ids=[1])
+
+        pipeline.test(pd.DataFrame({"foo": [1, 2, 2, 3, 4,5,6]},
+                      index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=7))),
+                      online_start=pd.to_datetime('2000-01-04'))
+
+        self.assertEqual(5, step_one.get_result.call_count)
+        self.assertEqual(2, step_one.reset.call_count)
+        reset_calls = [call(), call(keep_buffer=True)]
+        step_one.reset.assert_has_calls(reset_calls)
+        self.assertEqual(5, step_one.further_elements.call_count)

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -35,7 +35,7 @@ pipeline_json = {'id': 1,
                             'index': 'input',
                             'input_ids': {},
                             'last': False,
-                            'module': 'pywatts.core.start_step',
+                            'module': 'pywatts_pipeline.core.start_step',
                             'name': 'input',
                             'target_ids': {}},
                            {'batch_size': None,
@@ -46,7 +46,7 @@ pipeline_json = {'id': 1,
                             'id': 2,
                             'input_ids': {1: 'input'},
                             'last': False,
-                            'module': 'pywatts.core.step',
+                            'module': 'pywatts_pipeline.core.step',
                             'module_id': 0,
                             'name': 'StandardScaler',
                             'target_ids': {},
@@ -59,7 +59,7 @@ pipeline_json = {'id': 1,
                             'id': 3,
                             'input_ids': {2: 'x'},
                             'last': True,
-                            'module': 'pywatts.core.step',
+                            'module': 'pywatts_pipeline.core.step',
                             'module_id': 1,
                             'name': 'LinearRegression',
                             'target_ids': {},
@@ -69,7 +69,7 @@ pipeline_json = {'id': 1,
 
 class TestPipeline(unittest.TestCase):
 
-    @patch("pywatts.core.pipeline.FileManager")
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
     def setUp(self, fm_mock) -> None:
         self.fm_mock = fm_mock()
         self.pipeline = Pipeline()
@@ -115,8 +115,8 @@ class TestPipeline(unittest.TestCase):
         # Three modules plus start step and one collect step
         self.assertEqual(3, len(self.pipeline.id_to_step))
 
-    @patch('pywatts.core.pipeline.FileManager')
-    @patch('pywatts.core.pipeline.json')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.json')
     @patch("builtins.open", new_callable=mock_open)
     def test_to_folder(self, mock_file, json_mock, fm_mock):
         scaler = SKLearnWrapper(StandardScaler())(input=self.pipeline["input"])
@@ -142,11 +142,11 @@ class TestPipeline(unittest.TestCase):
         assert kwargs["obj"]["modules"] == pipeline_json["modules"]
         assert kwargs["obj"]["steps"] == pipeline_json["steps"]
 
-    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
     @patch('pywatts.modules.sklearn_wrapper.cloudpickle')
-    @patch('pywatts.core.pipeline.json')
+    @patch('pywatts_pipeline.core.pipeline.json')
     @patch("builtins.open", new_callable=mock_open)
-    @patch('pywatts.core.pipeline.os.path.isdir')
+    @patch('pywatts_pipeline.core.pipeline.os.path.isdir')
     def test_from_folder(self, isdir_mock, mock_file, json_mock, pickle_mock, fm_mock):
         scaler = StandardScaler()
         linear_regression = LinearRegression()
@@ -200,8 +200,8 @@ class TestPipeline(unittest.TestCase):
             pd.DataFrame({"test": [1, 2, 2, 3, 4], "test2": [2, 2, 2, 2, 2], "target": [2, 2, 4, 4, -5]},
                          index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=5))))
 
-    @patch('pywatts.core.pipeline.Pipeline._create_summary')
-    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.Pipeline._create_summary')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
     def test_add_pipeline_to_pipeline_and_train(self, fm_mock, create_summary_mock):
         sub_pipeline = Pipeline()
 
@@ -222,7 +222,7 @@ class TestPipeline(unittest.TestCase):
         assert 2 == create_summary_mock.call_count
         create_summary_mock.assert_has_calls([call(summary_formatter_mock, None), call(summary_formatter_mock, None)], any_order=True)
 
-    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
     def test_add_pipeline_to_pipeline_and_test(self, fm_mock):
         # Add some steps to the pipeline
 
@@ -248,8 +248,8 @@ class TestPipeline(unittest.TestCase):
 
         # step.reset.assert_called_once()
 
-    @patch("pywatts.core.pipeline.FileManager")
-    @patch('pywatts.core.pipeline.json')
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
+    @patch('pywatts_pipeline.core.pipeline.json')
     @patch("builtins.open", new_callable=mock_open)
     def test_add_pipeline_to_pipeline_and_save(self, open_mock, json_mock, fm_mock):
         sub_pipeline = Pipeline()
@@ -267,7 +267,7 @@ class TestPipeline(unittest.TestCase):
     def create_summary_in_subpipelines(self):
         assert False
 
-    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
     def test__collect_batch_results_naming_conflict(self, fm_mock):
         step_one = MagicMock()
         step_one.name = "step"
@@ -292,7 +292,7 @@ class TestPipeline(unittest.TestCase):
         # Assert return value is correct
         self.assertEqual(merged_result, result)
 
-    @patch("pywatts.core.pipeline.FileManager")
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
     def test_get_params(self, fm_mock):
         result = Pipeline(batch=pd.Timedelta("1h")).get_params()
         self.assertEqual(result, {
@@ -330,8 +330,8 @@ class TestPipeline(unittest.TestCase):
         # Assert return value is correct
         self.assertEqual(merged_result, result)
 
-    @patch("pywatts.core.pipeline.FileManager")
-    @patch("pywatts.core.pipeline.xr.concat")
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
+    @patch("pywatts_pipeline.core.pipeline.xr.concat")
     def test_batched_pipeline(self, concat_mock, fm_mock):
         # Add some steps to the pipeline
 
@@ -367,8 +367,8 @@ class TestPipeline(unittest.TestCase):
         first_step.get_result.assert_has_calls(calls, any_order=True)
         self.assertEqual(concat_mock.call_count, 3)
 
-    @patch("pywatts.core.pipeline.FileManager")
-    @patch("pywatts.core.pipeline.xr.concat")
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
+    @patch("pywatts_pipeline.core.pipeline.xr.concat")
     def test_batch_2H_transform(self, concat_mock, fm_mock):
         time = pd.date_range('2000-01-01', freq='1H', periods=7)
         da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
@@ -391,8 +391,8 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(step_one.further_elements.call_count, 5)
         self.assertEqual({"step": result_mock}, result)
 
-    @patch('pywatts.core.pipeline.FileManager')
-    @patch("pywatts.core.pipeline._get_time_indexes", return_value=["time"])
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
+    @patch("pywatts_pipeline.core.pipeline._get_time_indexes", return_value=["time"])
     def test_transform_pipeline(self, get_time_indexes_mock, fm_mock):
         input_mock = MagicMock()
         input_mock.indexes = {"time": ["20.12.2020"]}
@@ -409,22 +409,22 @@ class TestPipeline(unittest.TestCase):
         get_time_indexes_mock.assert_called_once_with({"x": input_mock})
         self.assertEqual({"mock": result_mock}, result)
 
-    @patch("pywatts.core.pipeline.FileManager")
-    @patch("pywatts.core.pipeline.Pipeline.from_folder")
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
+    @patch("pywatts_pipeline.core.pipeline.Pipeline.from_folder")
     def test_load(self, from_folder_mock, fm_mock):
         created_pipeline = MagicMock()
         from_folder_mock.return_value = created_pipeline
         pipeline = Pipeline.load({'name': 'Pipeline',
                                   'class': 'Pipeline',
-                                  'module': 'pywatts.core.pipeline',
+                                  'module': 'pywatts_pipeline.core.pipeline',
                                   'pipeline_path': 'save_path'})
 
         from_folder_mock.assert_called_once_with("save_path")
         self.assertEqual(created_pipeline, pipeline)
 
-    @patch("pywatts.core.pipeline.FileManager")
-    @patch("pywatts.core.pipeline.Pipeline.to_folder")
-    @patch("pywatts.core.pipeline.os")
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
+    @patch("pywatts_pipeline.core.pipeline.Pipeline.to_folder")
+    @patch("pywatts_pipeline.core.pipeline.os")
     def test_save(self, os_mock, to_folder_mock, fm_mock):
         os_mock.path.join.return_value = "save_path"
         os_mock.path.isdir.return_value = False
@@ -439,12 +439,12 @@ class TestPipeline(unittest.TestCase):
         os_mock.path.join.assert_called_once_with("path_to_save", "Pipeline")
         self.assertEqual({'name': 'Pipeline',
                           'class': 'Pipeline',
-                          'module': 'pywatts.core.pipeline',
+                          'module': 'pywatts_pipeline.core.pipeline',
                           'params': {'batch': '0 days 01:00:00'},
                           'pipeline_path': 'save_path'}, result)
 
-    @patch("pywatts.core.pipeline.FileManager")
-    @patch("pywatts.core.pipeline.xr.concat")
+    @patch("pywatts_pipeline.core.pipeline.FileManager")
+    @patch("pywatts_pipeline.core.pipeline.xr.concat")
     def test_batch_1_transform(self, concat_mock, fm_mock):
         time = pd.date_range('2000-01-01', freq='1H', periods=7)
         da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
@@ -467,7 +467,7 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(step_one.further_elements.call_count, 8)
         self.assertEqual({"step": result_mock}, result)
 
-    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
     def test_test(self, fm_mock):
         # Add some steps to the pipeline
 
@@ -504,7 +504,7 @@ class TestPipeline(unittest.TestCase):
         first_step.reset.assert_called_once()
         second_step.reset.assert_called_once()
 
-    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
     def test_train(self, fmmock):
         # Add some steps to the pipeline
         time = pd.date_range('2000-01-01', freq='1H', periods=7)
@@ -543,7 +543,7 @@ class TestPipeline(unittest.TestCase):
         second_step.reset.assert_called_once()
         xr.testing.assert_equal(result["second"], da)
 
-    @patch('pywatts.core.pipeline.FileManager')
+    @patch('pywatts_pipeline.core.pipeline.FileManager')
     def test_train_return_no_summary(self, fmmock):
         # Add some steps to the pipeline
         time = pd.date_range('2000-01-01', freq='1H', periods=7)
@@ -600,7 +600,7 @@ class TestPipeline(unittest.TestCase):
 
         self.assertTrue("target" in result.keys())
 
-    @patch('pywatts.core.pipeline.isinstance', return_value=True)
+    @patch('pywatts_pipeline.core.pipeline.isinstance', return_value=True)
     def test_refit(self, isinstance_mock):
         first_step = MagicMock()
         first_step.lag = pd.Timedelta("1d")

--- a/tests/unit/core/test_probabilistic_step.py
+++ b/tests/unit/core/test_probabilistic_step.py
@@ -34,6 +34,7 @@ class TestProbabilisticStep(unittest.TestCase):
         self.probabilistic_step.get_result(pd.Timestamp("2000.01.01"), pd.Timestamp("2000.01.02"))
 
         self.probabilistic_module.predict_proba.assert_not_called()
+        # TODO: Timestamp is passed to _should_stop which is not subscribable in step.py:218 minimum_data[0]
         self.assertTrue(self.probabilistic_step._should_stop(pd.Timestamp("2000.01.01"), pd.Timestamp("2000.01.02")))
 
     def test_transform_no_prob_method(self):
@@ -41,6 +42,7 @@ class TestProbabilisticStep(unittest.TestCase):
         self.probabilistic_module.name = "Magic"
 
         with self.assertRaises(KindOfTransformDoesNotExistException) as context:
+            # TODO: Fails because Tuple has no attribute dims in step.py:120
             self.probabilistic_step.get_result(None, None)
         self.assertEqual(f"The module Magic has no probablisitic transform", context.exception.message)
         self.assertEqual(KindOfTransform.PROBABILISTIC_TRANSFORM, context.exception.method)

--- a/tests/unit/core/test_probabilistic_step.py
+++ b/tests/unit/core/test_probabilistic_step.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock
+
+from pywatts_pipeline.core.exceptions.kind_of_transform_does_not_exist_exception import \
+    KindOfTransformDoesNotExistException, KindOfTransform
+from pywatts_pipeline.core.steps.probabilistic_step import ProbablisticStep
+import pandas as pd
+
+
+class TestProbabilisticStep(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.probabilistic_module = MagicMock()
+        self.input_step = MagicMock()
+        self.input_step.get_result.return_value = MagicMock(), False
+        self.input_step._should_stop.return_value = False
+        self.probabilistic_step = ProbablisticStep(self.probabilistic_module, {"x": self.input_step},
+                                                   file_manager=MagicMock())
+
+    def tearDown(self) -> None:
+        self.probabilistic_module = None
+        self.input_step = None
+        self.probabilistic_step = None
+
+    def test_transform(self):
+        input_mock = MagicMock()
+        self.probabilistic_step._transform(input_mock)
+
+        self.probabilistic_module.predict_proba.assert_called_once_with(input_mock)
+
+    def test_get_result_stop(self):
+        self.input_step.get_result.return_value = None
+
+        self.probabilistic_step.get_result(pd.Timestamp("2000.01.01"), pd.Timestamp("2000.01.02"))
+
+        self.probabilistic_module.predict_proba.assert_not_called()
+        self.assertTrue(self.probabilistic_step._should_stop(pd.Timestamp("2000.01.01"), pd.Timestamp("2000.01.02")))
+
+    def test_transform_no_prob_method(self):
+        self.probabilistic_module.has_predict_proba = False
+        self.probabilistic_module.name = "Magic"
+
+        with self.assertRaises(KindOfTransformDoesNotExistException) as context:
+            self.probabilistic_step.get_result(None, None)
+        self.assertEqual(f"The module Magic has no probablisitic transform", context.exception.message)
+        self.assertEqual(KindOfTransform.PROBABILISTIC_TRANSFORM, context.exception.method)
+
+        self.probabilistic_module.predict_proba.assert_not_called()

--- a/tests/unit/core/test_run_setting.py
+++ b/tests/unit/core/test_run_setting.py
@@ -1,0 +1,44 @@
+import unittest
+
+from pywatts_pipeline.core.util.computation_mode import ComputationMode
+from pywatts_pipeline.core.util.run_setting import RunSetting
+
+
+class TestRunSetting(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.run_setting = RunSetting(computation_mode=ComputationMode.Default)
+
+    def tearDown(self) -> None:
+        self.run_setting = None
+
+    def test_update(self):
+        run_setting = self.run_setting.update(RunSetting(computation_mode=ComputationMode.Train))
+        self.assertEqual(run_setting.computation_mode, ComputationMode.Train)
+
+    def test_update_computation_mode_not_updatable(self):
+        run_setting = RunSetting(computation_mode=ComputationMode.Train)
+        run_setting.update(RunSetting(computation_mode=ComputationMode.Transform))
+        self.assertEqual(run_setting.computation_mode, ComputationMode.Train)
+
+        run_setting = RunSetting(computation_mode=ComputationMode.Transform)
+        run_setting.update(RunSetting(computation_mode=ComputationMode.Train))
+        self.assertEqual(run_setting.computation_mode, ComputationMode.Transform)
+
+    def test_clone(self):
+        run_setting = self.run_setting.clone()
+
+        self.assertEqual(run_setting.computation_mode, self.run_setting.computation_mode)
+
+    def test_save(self):
+        json = self.run_setting.save()
+
+        self.assertEqual(json, {
+            "computation_mode": 4
+        })
+
+    def test_load(self):
+        run_setting = RunSetting.load({
+            "computation_mode": 4
+        })
+        self.assertEqual(run_setting.computation_mode, ComputationMode.Default)

--- a/tests/unit/core/test_start_step.py
+++ b/tests/unit/core/test_start_step.py
@@ -16,7 +16,7 @@ class TestStartStep(unittest.TestCase):
             "input_ids": {},
             "id": -1,
             'default_run_setting': {'computation_mode': 4},
-            "module": "pywatts.core.start_step",
+            "module": "pywatts_pipeline.core.steps.start_step",
             "class": "StartStep",
             "name": "StartStep",
             "last": False

--- a/tests/unit/core/test_start_step.py
+++ b/tests/unit/core/test_start_step.py
@@ -1,0 +1,46 @@
+import unittest
+import pandas as pd
+import xarray as xr
+
+from unittest.mock import MagicMock
+
+from pywatts_pipeline.core.steps.start_step import StartStep
+
+
+class TestStartStep(unittest.TestCase):
+
+    def test_load(self):
+        params = {
+            "index": "SomeIndex",
+            "target_ids": {},
+            "input_ids": {},
+            "id": -1,
+            'default_run_setting': {'computation_mode': 4},
+            "module": "pywatts.core.start_step",
+            "class": "StartStep",
+            "name": "StartStep",
+            "last": False
+        }
+        step = StartStep(None).load(params, None, None, None, None)
+        json = step.get_json("file")
+        self.assertEqual(params, json)
+
+    def test_get_result_copying(self):
+        # Tests if the get_result method calls correctly the previous step and the module
+
+        input_step = MagicMock()
+        input_step_result_mock = MagicMock()
+        input_step.get_result.return_value = input_step_result_mock
+        input_step._should_stop.return_value = False
+
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+        step = StartStep("x")
+        step.buffer = {"x": xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"],
+                                         coords={'time': time})}
+        result1 = step.get_result(None, None)
+        result2 = step.get_result(None, None)
+
+        # result1 and result2 has to be different objects
+        result1[1] = 20
+
+        self.assertNotEqual(result1[1], result2[1])

--- a/tests/unit/core/test_step.py
+++ b/tests/unit/core/test_step.py
@@ -148,6 +148,7 @@ class TestStep(unittest.TestCase):
         self.module_mock.transform.return_value = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"],
                                                                coords={'time': time})
         step = Step(self.module_mock, {"x": input_step}, file_manager=MagicMock())
+        # TODO: I think get results awaits list of time indexes?
         step.get_result(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.12.12"))
 
         # Two calls, once in should_stop and once in _transform
@@ -211,6 +212,7 @@ class TestStep(unittest.TestCase):
         input_dict = {'input_data': None}
         step = Step(self.module_mock, {"x": self.step_mock}, None)
         step._fit(input_dict, {})
+        # TODO input_dict has no attribute dims
         step._transform(input_dict)
         self.module_mock.transform.assert_called_once_with(**input_dict)
 
@@ -277,6 +279,7 @@ class TestStep(unittest.TestCase):
 
         self.assertIsNone(None)
         assert step.current_run_setting.computation_mode == ComputationMode.Default
+        # TODO: None type does not support index access
         assert step._should_stop(None, None) == False
         assert step.finished == False
 
@@ -287,6 +290,7 @@ class TestStep(unittest.TestCase):
     def test_refit_refit_conditions_false(self, isinstance_mock, get_input_mock, get_target_mock):
         step = Step(self.module_mock, {"x": self.step_mock}, file_manager=None, refit_conditions=[lambda x, y: False],
                     computation_mode=ComputationMode.Refit)
+        # TODO: Timestamp has no attribute dims
         step.refit(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.01.01"))
         self.module_mock.refit.assert_not_called()
 
@@ -309,9 +313,3 @@ class TestStep(unittest.TestCase):
                     computation_mode=ComputationMode.Refit)
         step.refit(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.01.01"))
         self.module_mock.refit.assert_called_once_with(x=2, target=1)
-
-    def test_has_to_renew_buffer(self):
-        self.fail()
-
-    def test_renew_buffer(self):
-        self.fail()

--- a/tests/unit/core/test_step.py
+++ b/tests/unit/core/test_step.py
@@ -29,7 +29,7 @@ class TestStep(unittest.TestCase):
         self.module_mock.fit.assert_called_once_with(**input_dict)
 
     @patch("builtins.open")
-    @patch("pywatts.core.step.cloudpickle")
+    @patch("pywatts_pipeline.core.step.cloudpickle")
     def test_store_load_of_step_with_condition(self, cloudpickle_mock, open_mock):
         condition_mock = MagicMock()
         step = Step(self.module_mock, self.step_mock, None, condition=condition_mock)
@@ -51,7 +51,7 @@ class TestStep(unittest.TestCase):
             "id": -1,
             'default_run_setting': {'computation_mode': 4},
             "refit_conditions": [],
-            "module": "pywatts.core.step",
+            "module": "pywatts_pipeline.core.step",
             "class": "Step",
             "name": "test",
             'callbacks': [],
@@ -64,7 +64,7 @@ class TestStep(unittest.TestCase):
         cloudpickle_mock.dump.assert_called_once_with(condition_mock, open_mock().__enter__.return_value)
 
     @patch("builtins.open")
-    @patch("pywatts.core.step.cloudpickle")
+    @patch("pywatts_pipeline.core.step.cloudpickle")
     def test_store_load_of_step_with_refit_conditions(self, cloudpickle_mock, open_mock):
         refit_conditions_mock = MagicMock()
         step = Step(self.module_mock, self.step_mock, None, refit_conditions=[refit_conditions_mock])
@@ -87,7 +87,7 @@ class TestStep(unittest.TestCase):
             'batch_size': None,
             'default_run_setting': {'computation_mode': 4},
             "refit_conditions": [os.path.join("folder", "test_refit_conditions.pickle")],
-            "module": "pywatts.core.step",
+            "module": "pywatts_pipeline.core.step",
             "class": "Step",
             "name": "test",
             'callbacks': [],
@@ -100,8 +100,8 @@ class TestStep(unittest.TestCase):
         cloudpickle_mock.load.assert_called_once_with(open_mock().__enter__.return_value)
         cloudpickle_mock.dump.assert_called_once_with(refit_conditions_mock, open_mock().__enter__.return_value)
 
-    @patch("pywatts.core.base_step._get_time_indexes", return_value=["time"])
-    @patch("pywatts.core.base_step.xr")
+    @patch("pywatts_pipeline.core.base_step._get_time_indexes", return_value=["time"])
+    @patch("pywatts_pipeline.core.base_step.xr")
     def test_transform_batch_with_existing_buffer(self, xr_mock, *args):
         # Check that data in batch learning are concatenated
         input_step = MagicMock()
@@ -220,7 +220,7 @@ class TestStep(unittest.TestCase):
             "input_ids": {2: 'x'},
             'default_run_setting': {'computation_mode': 3},
             "id": -1,
-            "module": "pywatts.core.step",
+            "module": "pywatts_pipeline.core.step",
             "class": "Step",
             "condition": None,
             "refit_conditions": [],
@@ -246,7 +246,7 @@ class TestStep(unittest.TestCase):
                           'id': -1,
                           'input_ids': {},
                           'last': True,
-                          'module': 'pywatts.core.step',
+                          'module': 'pywatts_pipeline.core.step',
                           'name': 'test',
                           'target_ids': {},
                           'refit_conditions': []}, json)
@@ -280,18 +280,18 @@ class TestStep(unittest.TestCase):
         assert step.finished == False
 
 
-    @patch('pywatts.core.step.Step._get_target', return_value={"target": 1})
-    @patch('pywatts.core.step.Step._get_input', return_value={"x": 2})
-    @patch('pywatts.core.step.isinstance', side_effect=[True, False, True])
+    @patch('pywatts_pipeline.core.step.Step._get_target', return_value={"target": 1})
+    @patch('pywatts_pipeline.core.step.Step._get_input', return_value={"x": 2})
+    @patch('pywatts_pipeline.core.step.isinstance', side_effect=[True, False, True])
     def test_refit_refit_conditions_false(self, isinstance_mock, get_input_mock, get_target_mock):
         step = Step(self.module_mock, {"x": self.step_mock}, file_manager=None, refit_conditions=[lambda x, y: False],
                     computation_mode=ComputationMode.Refit)
         step.refit(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.01.01"))
         self.module_mock.refit.assert_not_called()
 
-    @patch('pywatts.core.step.Step._get_target', return_value={"target": 1})
-    @patch('pywatts.core.step.Step._get_input', return_value={"x": 2})
-    @patch('pywatts.core.step.isinstance', side_effect=[True, False, True])
+    @patch('pywatts_pipeline.core.step.Step._get_target', return_value={"target": 1})
+    @patch('pywatts_pipeline.core.step.Step._get_input', return_value={"x": 2})
+    @patch('pywatts_pipeline.core.step.isinstance', side_effect=[True, False, True])
     def test_refit_refit_conditions_true(self, isinstance_mock, get_input_mock, get_target_mock):
         step = Step(self.module_mock, {"x": self.step_mock},
                     targets={"target": self.step_mock}, file_manager=None, refit_conditions=[lambda x, y: True],
@@ -299,9 +299,9 @@ class TestStep(unittest.TestCase):
         step.refit(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.01.01"))
         self.module_mock.refit.assert_called_once_with(x=2, target=1)
 
-    @patch('pywatts.core.step.Step._get_target', return_value={"target": 1})
-    @patch('pywatts.core.step.Step._get_input', return_value={"x": 2})
-    @patch('pywatts.core.step.isinstance', side_effect=[True, False, True, False, True])
+    @patch('pywatts_pipeline.core.step.Step._get_target', return_value={"target": 1})
+    @patch('pywatts_pipeline.core.step.Step._get_input', return_value={"x": 2})
+    @patch('pywatts_pipeline.core.step.isinstance', side_effect=[True, False, True, False, True])
     def test_multiple_refit_conditions(self, isinstance_mock, get_input_mock, get_target_mock):
         step = Step(self.module_mock, {"x": self.step_mock},
                     targets={"target": self.step_mock}, file_manager=None, refit_conditions=[lambda x, y: False, lambda x, y: True],

--- a/tests/unit/core/test_step.py
+++ b/tests/unit/core/test_step.py
@@ -1,0 +1,316 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from pywatts_pipeline.core.util.computation_mode import ComputationMode
+from pywatts_pipeline.core.steps.step import Step
+from pywatts_pipeline.core.util.run_setting import RunSetting
+
+
+class TestStep(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module_mock = MagicMock()
+        self.module_mock.name = "test"
+        self.step_mock = MagicMock()
+        self.step_mock.id = 2
+
+    def tearDown(self) -> None:
+        self.module_mock = None
+        self.step_mock = None
+
+    def test_fit(self):
+        input_dict = {'input_data': None}
+        step = Step(self.module_mock, self.step_mock, file_manager=MagicMock())
+        step._fit(input_dict, {})
+        self.module_mock.fit.assert_called_once_with(**input_dict)
+
+    @patch("builtins.open")
+    @patch("pywatts.core.step.cloudpickle")
+    def test_store_load_of_step_with_condition(self, cloudpickle_mock, open_mock):
+        condition_mock = MagicMock()
+        step = Step(self.module_mock, self.step_mock, None, condition=condition_mock)
+        fm_mock = MagicMock()
+        fm_mock.get_path.return_value = os.path.join("folder", "test_condition.pickle")
+        json = step.get_json(fm_mock)
+        reloaded_step = Step.load(json, [self.step_mock], targets=None, module=self.module_mock,
+                                  file_manager=MagicMock())
+
+        # One call in load and one in save
+        open_mock.assert_has_calls(
+            [call(os.path.join("folder", "test_condition.pickle"), "wb"),
+             call(os.path.join("folder", "test_condition.pickle"), "rb")],
+            any_order=True)
+        self.assertEqual(json, {
+            "target_ids": {},
+            'batch_size': None,
+            "input_ids": {},
+            "id": -1,
+            'default_run_setting': {'computation_mode': 4},
+            "refit_conditions": [],
+            "module": "pywatts.core.step",
+            "class": "Step",
+            "name": "test",
+            'callbacks': [],
+            "last": True,
+            'condition': os.path.join("folder", "test_condition.pickle")}, json)
+
+        self.assertEqual(reloaded_step.module, self.module_mock)
+        self.assertEqual(reloaded_step.input_steps, [self.step_mock])
+        cloudpickle_mock.load.assert_called_once_with(open_mock().__enter__.return_value)
+        cloudpickle_mock.dump.assert_called_once_with(condition_mock, open_mock().__enter__.return_value)
+
+    @patch("builtins.open")
+    @patch("pywatts.core.step.cloudpickle")
+    def test_store_load_of_step_with_refit_conditions(self, cloudpickle_mock, open_mock):
+        refit_conditions_mock = MagicMock()
+        step = Step(self.module_mock, self.step_mock, None, refit_conditions=[refit_conditions_mock])
+        fm_mock = MagicMock()
+        fm_mock.get_path.return_value = os.path.join("folder", "test_refit_conditions.pickle")
+        json = step.get_json(fm_mock)
+        reloaded_step = Step.load(json, [self.step_mock], targets=None, module=self.module_mock,
+                                  file_manager=MagicMock())
+
+        # One call in load and one in save
+        open_mock.assert_has_calls(
+            [call(os.path.join("folder", "test_refit_conditions.pickle"), "wb"),
+             call(os.path.join("folder", "test_refit_conditions.pickle"), "rb")],
+            any_order=True)
+        self.assertEqual(json, {
+            "target_ids": {},
+            # Same as for test_load.
+            "input_ids": {},
+            "id": -1,
+            'batch_size': None,
+            'default_run_setting': {'computation_mode': 4},
+            "refit_conditions": [os.path.join("folder", "test_refit_conditions.pickle")],
+            "module": "pywatts.core.step",
+            "class": "Step",
+            "name": "test",
+            'callbacks': [],
+            "last": True,
+
+            'condition': None}, json),
+
+        self.assertEqual(reloaded_step.module, self.module_mock)
+        self.assertEqual(reloaded_step.input_steps, [self.step_mock])
+        cloudpickle_mock.load.assert_called_once_with(open_mock().__enter__.return_value)
+        cloudpickle_mock.dump.assert_called_once_with(refit_conditions_mock, open_mock().__enter__.return_value)
+
+    @patch("pywatts.core.base_step._get_time_indexes", return_value=["time"])
+    @patch("pywatts.core.base_step.xr")
+    def test_transform_batch_with_existing_buffer(self, xr_mock, *args):
+        # Check that data in batch learning are concatenated
+        input_step = MagicMock()
+        input_step._should_stop.return_value = False
+        time = pd.date_range('2000-01-01', freq='1D', periods=7)
+        time2 = pd.date_range('2000-01-14', freq='1D', periods=7)
+        time3 = pd.date_range('2000-01-01', freq='1D', periods=14)
+
+        self.module_mock.transform.return_value = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"],
+                                                               coords={'time': time2})
+        self.module_mock.get_min_data.return_value = 2
+        step = Step(self.module_mock, {"x": input_step}, file_manager=MagicMock())
+        da = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})
+        step.buffer = {"test": da}
+        xr_mock.concat.return_value = xr.DataArray([2, 3, 4, 3, 3, 1, 2, 2, 3, 4, 3, 3, 1, 2], dims=["time"],
+                                                   coords={'time': time3})
+
+        step.get_result(pd.Timestamp("2000.01.07"), pd.Timestamp("2020.01.14"))
+
+        # Two calls, once in should_stop and once in _transform
+        input_step.get_result.assert_has_calls(
+            [call(pd.Timestamp('2000-01-07 00:00:00'), pd.Timestamp('2020-01-14 00:00:00'),
+                  minimum_data=(2, pd.Timedelta(0))),
+             call(pd.Timestamp('2000-01-07 00:00:00'), pd.Timestamp('2020-01-14 00:00:00'),
+                  minimum_data=(2, pd.Timedelta(0)))])
+        xr_mock.concat.assert_called_once()
+
+        xr.testing.assert_equal(da, list(xr_mock.concat.call_args_list[0])[0][0][0])
+        xr.testing.assert_equal(xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"],
+                                             coords={'time': time2}), list(xr_mock.concat.call_args_list[0])[0][0][1])
+        assert {'dim': 'time'} == list(xr_mock.concat.call_args_list[0])[1]
+
+    def test_get_result_recalculate(self):
+        pass
+
+    def test_get_result(self):
+        input_step = MagicMock()
+        input_step_result_mock = MagicMock()
+        input_step.get_result.return_value = input_step_result_mock
+        input_step._should_stop.return_value = False
+
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+        self.module_mock.transform.return_value = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"],
+                                                               coords={'time': time})
+        step = Step(self.module_mock, {"x": input_step}, file_manager=MagicMock())
+        step.get_result(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.12.12"))
+
+        # Two calls, once in should_stop and once in _transform
+        input_step.get_result.assert_has_calls(
+            [call(pd.Timestamp("2000-01-01"), pd.Timestamp('2020-12-12 '),
+                  minimum_data=(0, self.module_mock.get_min_data().__radd__()),
+                  use_result_buffer=False),
+             call(pd.Timestamp('2000-01-01 '), pd.Timestamp('2020-12-12 '),
+                  minimum_data=(0, self.module_mock.get_min_data().__radd__()))],
+                  use_result_buffer=False)
+
+        self.module_mock.transform.assert_called_once_with(x=input_step_result_mock)
+
+    def test_further_elements_input_false(self):
+        input_step = MagicMock()
+        input_step.further_elements.return_value = False
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+        step = Step(self.module_mock, {"x": input_step}, file_manager=MagicMock())
+        step.buffer = {"STEP": xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})}
+
+        result = step.further_elements(pd.Timestamp("2000.12.12"))
+        input_step.further_elements.assert_called_once_with(pd.Timestamp("2000.12.12"))
+        self.assertFalse(result)
+
+    def test_further_elements_target_false(self):
+        target_step = MagicMock()
+        target_step.further_elements.return_value = False
+        time = pd.date_range('2000-01-01', freq='1H', periods=7)
+        step = Step(self.module_mock, {"x": self.step_mock}, targets={"target": target_step}, file_manager=MagicMock())
+        step.buffer = {"STEP": xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})}
+
+        result = step.further_elements(pd.Timestamp("2000.12.12"))
+        target_step.further_elements.assert_called_once_with(pd.Timestamp("2000.12.12"))
+        self.assertFalse(result)
+
+    def test_further_elements_already_buffered(self):
+        time = pd.date_range('2000-01-01', freq='24H', periods=7)
+        step = Step(self.module_mock, {"x": self.step_mock}, file_manager=MagicMock())
+        step.buffer = {"STEP": xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"], coords={'time': time})}
+        result = step.further_elements(pd.Timestamp("2000-01-05"))
+        self.step_mock.further_elements.assert_not_called()
+        self.assertEqual(result, True)
+
+    def test_input_finished(self):
+        input_dict = {'input_data': None}
+        step = Step(self.module_mock, self.step_mock, file_manager=MagicMock())
+        step._fit(input_dict, {})
+
+        self.module_mock.fit.assert_called_once_with(**input_dict)
+
+    def test_fit_with_targets(self):
+        input_dict = {'input_data': None}
+        target_mock = MagicMock()
+
+        step = Step(self.module_mock, self.step_mock, MagicMock(), targets={"target": MagicMock()})
+        step._fit(input_dict, {"target": target_mock})
+
+        self.module_mock.fit.assert_called_once_with(**input_dict, target=target_mock)
+
+    def test_transform(self):
+        input_dict = {'input_data': None}
+        step = Step(self.module_mock, {"x": self.step_mock}, None)
+        step._fit(input_dict, {})
+        step._transform(input_dict)
+        self.module_mock.transform.assert_called_once_with(**input_dict)
+
+    def test_load(self):
+        step_config = {
+            'batch_size': None,
+            "target_ids": {},
+            "input_ids": {2: 'x'},
+            'default_run_setting': {'computation_mode': 3},
+            "id": -1,
+            "module": "pywatts.core.step",
+            "class": "Step",
+            "condition": None,
+            "refit_conditions": [],
+            'callbacks': [],
+            "name": "test",
+            "last": False,
+        }
+        step = Step.load(step_config, {'x': self.step_mock}, None, self.module_mock, None)
+
+        self.assertEqual(step.name, "test")
+        self.assertEqual(step.id, -1)
+        self.assertEqual(step.get_json("file"), step_config)
+        self.assertEqual(step.module, self.module_mock)
+
+    def test_get_json(self):
+        step = Step(self.module_mock, self.step_mock, None)
+        json = step.get_json("file")
+        self.assertEqual({'batch_size': None,
+                          'callbacks': [],
+                          'class': 'Step',
+                          'default_run_setting': {'computation_mode': 4},
+                          'condition': None,
+                          'id': -1,
+                          'input_ids': {},
+                          'last': True,
+                          'module': 'pywatts.core.step',
+                          'name': 'test',
+                          'target_ids': {},
+                          'refit_conditions': []}, json)
+
+    def test_set_run_setting(self):
+        step = Step(MagicMock(), MagicMock(), MagicMock())
+        step.set_run_setting(RunSetting(ComputationMode.FitTransform))
+
+        assert step.current_run_setting.computation_mode == ComputationMode.FitTransform
+
+        step.set_run_setting(RunSetting(ComputationMode.Transform))
+        assert step.current_run_setting.computation_mode == ComputationMode.Transform
+
+    def test_set_computation_mode_specified(self):
+        step = Step(MagicMock(), MagicMock(), MagicMock(), computation_mode=ComputationMode.FitTransform)
+        assert step.current_run_setting.computation_mode == ComputationMode.FitTransform
+
+        step.set_run_setting(RunSetting(computation_mode=ComputationMode.Transform))
+        assert step.current_run_setting.computation_mode == ComputationMode.FitTransform
+
+    def test_reset(self):
+        step = Step(MagicMock(), MagicMock(), MagicMock())
+        step.buffer = MagicMock()
+        step.current_run_setting = RunSetting(computation_mode=ComputationMode.Transform)
+        step.finished = True
+        step.reset()
+
+        self.assertIsNone(None)
+        assert step.current_run_setting.computation_mode == ComputationMode.Default
+        assert step._should_stop(None, None) == False
+        assert step.finished == False
+
+
+    @patch('pywatts.core.step.Step._get_target', return_value={"target": 1})
+    @patch('pywatts.core.step.Step._get_input', return_value={"x": 2})
+    @patch('pywatts.core.step.isinstance', side_effect=[True, False, True])
+    def test_refit_refit_conditions_false(self, isinstance_mock, get_input_mock, get_target_mock):
+        step = Step(self.module_mock, {"x": self.step_mock}, file_manager=None, refit_conditions=[lambda x, y: False],
+                    computation_mode=ComputationMode.Refit)
+        step.refit(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.01.01"))
+        self.module_mock.refit.assert_not_called()
+
+    @patch('pywatts.core.step.Step._get_target', return_value={"target": 1})
+    @patch('pywatts.core.step.Step._get_input', return_value={"x": 2})
+    @patch('pywatts.core.step.isinstance', side_effect=[True, False, True])
+    def test_refit_refit_conditions_true(self, isinstance_mock, get_input_mock, get_target_mock):
+        step = Step(self.module_mock, {"x": self.step_mock},
+                    targets={"target": self.step_mock}, file_manager=None, refit_conditions=[lambda x, y: True],
+                    computation_mode=ComputationMode.Refit)
+        step.refit(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.01.01"))
+        self.module_mock.refit.assert_called_once_with(x=2, target=1)
+
+    @patch('pywatts.core.step.Step._get_target', return_value={"target": 1})
+    @patch('pywatts.core.step.Step._get_input', return_value={"x": 2})
+    @patch('pywatts.core.step.isinstance', side_effect=[True, False, True, False, True])
+    def test_multiple_refit_conditions(self, isinstance_mock, get_input_mock, get_target_mock):
+        step = Step(self.module_mock, {"x": self.step_mock},
+                    targets={"target": self.step_mock}, file_manager=None, refit_conditions=[lambda x, y: False, lambda x, y: True],
+                    computation_mode=ComputationMode.Refit)
+        step.refit(pd.Timestamp("2000.01.01"), pd.Timestamp("2020.01.01"))
+        self.module_mock.refit.assert_called_once_with(x=2, target=1)
+
+    def test_has_to_renew_buffer(self):
+        self.fail()
+
+    def test_renew_buffer(self):
+        self.fail()

--- a/tests/unit/core/test_summary_formatter.py
+++ b/tests/unit/core/test_summary_formatter.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import pandas as pd
+import numpy as np
+
+from pywatts_pipeline.core.summary.summary_object import SummaryObjectList, SummaryCategory, SummaryObjectTable
+from pywatts_pipeline.core.summary.summary_formatter import SummaryMarkdown, SummaryJSON
+
+
+class TestSummaryMarkdown(unittest.TestCase):
+
+    @patch("builtins.open")
+    def test_create_summary(self, open_mock):
+        summary_object = SummaryObjectList("name", category=SummaryCategory.FitTime,
+                                           additional_information="additional_information")
+        summary_object.set_kv("a", 1)
+        summary_object.set_kv("b", 2)
+
+        summary_object2 = SummaryObjectTable("name", category=SummaryCategory.Summary,
+                                             additional_information="additional_information")
+        summary_object2.set_kv("a", pd.DataFrame({"a": [1, 1]}))
+        summary_object2.set_kv("b", pd.DataFrame({"b": [2, 2]}))
+
+        fm_mock = MagicMock()
+
+        summary_formatter = SummaryMarkdown()
+
+        expected_result = '# Summary: \n## Summary\n### name\nadditional_information\n#### a\n ' \
+                          '|   0 |   1 |\n|-----|-----|\n|   0 |   1 |\n|   1 |   1 |\n' \
+                          '#### b\n |   0 |   1 |\n|-----|-----|\n|   0 |   2 |\n|   1 |   2 |\n' \
+                          '## FitTime\n### name\nadditional_information\n* a : 1\n* b : 2\n## TransformTime\n'
+        fm_mock.get_path.return_value = "file.md"
+
+        summary_string = summary_formatter.create_summary([summary_object, summary_object2], fm_mock)
+
+        fm_mock.get_path.assert_called_once_with("summary.md")
+        open_mock.assert_has_calls([call("file.md", "w")], any_order=True)
+
+        self.assertEqual(expected_result, summary_string)
+
+
+class TestSummaryJson(unittest.TestCase):
+
+    @patch("builtins.open")
+    def test_create_summary(self, open_mock):
+        summary_object = SummaryObjectList("name", category=SummaryCategory.FitTime,
+                                           additional_information="additional_information")
+        summary_object.set_kv("a", 1)
+        summary_object.set_kv("b", 2)
+
+        summary_object2 = SummaryObjectTable("name", category=SummaryCategory.Summary,
+                                             additional_information="additional_information")
+        summary_object2.set_kv("a", np.array([1, 1]))
+        summary_object2.set_kv("b", np.array([2, 2]))
+
+        fm_mock = MagicMock()
+
+        summary_formatter = SummaryJSON()
+
+        expected_result = {'Summary': {
+            'name': {'additional_information': 'additional_information', 'results': {'a': [1, 1], 'b': [2, 2]}}},
+                           'FitTime': {'name': {'additional_information': 'additional_information',
+                                                'results': {'a': 1, 'b': 2}}}, 'TransformTime': {}}
+        fm_mock.get_path.return_value = "file.md"
+
+        summary_json = summary_formatter.create_summary([summary_object, summary_object2], fm_mock)
+
+        fm_mock.get_path.assert_called_once_with("summary.json")
+        open_mock.assert_has_calls([call("file.md", "w")], any_order=True)
+
+        self.assertEqual(expected_result, summary_json)

--- a/tests/unit/core/test_summary_object.py
+++ b/tests/unit/core/test_summary_object.py
@@ -1,0 +1,17 @@
+import unittest
+
+from pywatts.core.summary_object import SummaryObjectList, SummaryCategory
+
+
+class TestSummaryObjectList(unittest.TestCase):
+
+    def test_set_kv(self):
+        summary_object = SummaryObjectList("name", category=SummaryCategory.FitTime,
+                                           additional_information="additional_information")
+        summary_object.set_kv("a", 1)
+        summary_object.set_kv("b", 2)
+
+        self.assertEqual("name", summary_object.name)
+        self.assertEqual("additional_information", summary_object.additional_information)
+        self.assertEqual(SummaryCategory.FitTime, summary_object.category)
+        self.assertEqual({"a": 1, "b": 2}, summary_object.k_v)

--- a/tests/unit/core/test_summary_object.py
+++ b/tests/unit/core/test_summary_object.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pywatts.core.summary_object import SummaryObjectList, SummaryCategory
+from pywatts_pipeline.core.summary.summary_object import SummaryObjectList, SummaryCategory
 
 
 class TestSummaryObjectList(unittest.TestCase):

--- a/tests/unit/core/test_summary_step.py
+++ b/tests/unit/core/test_summary_step.py
@@ -41,7 +41,7 @@ class TestSummaryStep(unittest.TestCase):
             "target_ids": {},
             "input_ids": {2  : "input"},
             "id": -1,
-            "module": "pywatts.core.summary_step",
+            "module": "pywatts_pipeline.core.summary_step",
             "class": "SummaryStep",
             "name": "test"}
 
@@ -59,6 +59,6 @@ class TestSummaryStep(unittest.TestCase):
             "target_ids": {},
             "input_ids": {2  : "input"},
             "id": -1,
-            "module": "pywatts.core.summary_step",
+            "module": "pywatts_pipeline.core.summary_step",
             "class": "SummaryStep",
             "name": "test"}, json)

--- a/tests/unit/core/test_summary_step.py
+++ b/tests/unit/core/test_summary_step.py
@@ -1,0 +1,64 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from pywatts_pipeline.core.summary.summary_step import SummaryStep
+
+
+class TestSummaryStep(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module_mock = MagicMock()
+        self.module_mock.transform.return_value = "#I AM MARKDOWN"
+        self.module_mock.name = "test"
+
+        self.result_mock = MagicMock()
+        self.step_mock = MagicMock()
+        self.step_mock.get_result.return_value = self.result_mock
+        self.step_mock.id = 2
+        self.fm_mock = MagicMock()
+        self.summary = SummaryStep(self.module_mock, {"input": self.step_mock}, self.fm_mock)
+
+    def tearDown(self) -> None:
+        self.module_mock = None
+        self.step_mock = None
+        self.summary = None
+        self.fm_mock = None
+
+    def test_get_summary(self):
+        self.module_mock.get_min_data.return_value = pd.Timedelta(hours=1)
+        result = self.summary.get_summary(None, None)
+
+        self.step_mock.get_result.assert_called_once_with(None, None, minimum_data=(0, pd.Timedelta(hours=1)))
+        self.module_mock.transform.assert_called_once_with(file_manager=self.fm_mock, input=self.result_mock)
+        self.assertEqual(result, "#I AM MARKDOWN")
+
+    def test_load(self):
+        stored_step = {
+            "target_ids": {},
+            "input_ids": {2  : "input"},
+            "id": -1,
+            "module": "pywatts.core.summary_step",
+            "class": "SummaryStep",
+            "name": "test"}
+
+        summary = SummaryStep.load(stored_step,{"input":self.step_mock}, {}, self.module_mock, self.fm_mock)
+        self.assertEqual(len(summary.input_steps), 1)
+        self.assertEqual(summary.input_steps["input"], self.step_mock)
+        self.assertEqual(summary.module, self.module_mock)
+        self.assertEqual(summary.file_manager, self.fm_mock)
+
+    def test_store(self):
+        fm_mock = MagicMock()
+        json = self.summary.get_json(fm_mock)
+
+        self.assertEqual(json, {
+            "target_ids": {},
+            "input_ids": {2  : "input"},
+            "id": -1,
+            "module": "pywatts.core.summary_step",
+            "class": "SummaryStep",
+            "name": "test"}, json)

--- a/tests/unit/core/test_summary_step.py
+++ b/tests/unit/core/test_summary_step.py
@@ -30,9 +30,9 @@ class TestSummaryStep(unittest.TestCase):
 
     def test_get_summary(self):
         self.module_mock.get_min_data.return_value = pd.Timedelta(hours=1)
-        result = self.summary.get_summary(None, None)
+        result = self.summary.get_summary(None)
 
-        self.step_mock.get_result.assert_called_once_with(None, None, minimum_data=(0, pd.Timedelta(hours=1)))
+        self.step_mock.get_result.assert_called_once_with(None, minimum_data=(0, pd.Timedelta(hours=1)))
         self.module_mock.transform.assert_called_once_with(file_manager=self.fm_mock, input=self.result_mock)
         self.assertEqual(result, "#I AM MARKDOWN")
 
@@ -41,7 +41,7 @@ class TestSummaryStep(unittest.TestCase):
             "target_ids": {},
             "input_ids": {2  : "input"},
             "id": -1,
-            "module": "pywatts_pipeline.core.summary_step",
+            'module': 'pywatts_pipeline.core.summary.summary_step',
             "class": "SummaryStep",
             "name": "test"}
 
@@ -59,6 +59,6 @@ class TestSummaryStep(unittest.TestCase):
             "target_ids": {},
             "input_ids": {2  : "input"},
             "id": -1,
-            "module": "pywatts_pipeline.core.summary_step",
+            'module': 'pywatts_pipeline.core.summary.summary_step',
             "class": "SummaryStep",
             "name": "test"}, json)


### PR DESCRIPTION
- [x] test_either_or_step.py -> Updated either_or_step.py
- [x] test_filemanager.py -> missing distlib in setup.py
- [ ] test_inverse_step.py !-> Tests failing
- [ ] test_pipeline.py !-> Tests have dependencies to pyWATTS, e.g., SklearnWrapper
- [ ] test_probabilistic_step.py !-> Tests failing
- [x] test_run_setting.py
- [x] test_start_step.py
- [ ] test_step.py !-> Tests failing
- [x] test_summary_formatter.py
- [x] test_summary_object.py
- [ ] test_summary_step.py !-> Tests failling