### PR TITLE
Fixed summary step crashing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,5 @@
 ### Fixed
 
   * Fixed pipeline path is none error ([#16](https://github.com/KIT-IAI/pywatts-pipeline/issues/16))
+  * Fixed summary step crashing ([#25](https://github.com/KIT-IAI/pywatts-pipeline/issues/25))
 

--- a/pywatts_pipeline/core/steps/start_step.py
+++ b/pywatts_pipeline/core/steps/start_step.py
@@ -19,7 +19,7 @@ class StartStep(BaseStep):
     def get_result(
         self, start: pd.Timestamp, return_all=False, minimum_data=(0, pd.Timedelta(0))
     ):
-        return self._pack_data(start, minimum_data=minimum_data)
+        return self._pack_data(start, minimum_data=minimum_data, return_all=return_all)
 
     @classmethod
     def load(cls, stored_step: dict, inputs, targets, module, file_manager):


### PR DESCRIPTION
## Description
Summary step crashing if pipeline only contains one summary step. Fixed by adding return_all=return_all in get_result of StartStep.

## Related Issues
closes #25 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos)
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Did you update the CHANGELOG

## PR review
Anyone in the community is free to review the PR once the tests have passed.

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones to the PR so it can be classified
