### PR TITLE
The pipeline's result and the buffer of all steps should be resetted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,5 @@
 
   * Fixed pipeline path is none error ([#16](https://github.com/KIT-IAI/pywatts-pipeline/issues/16))
   * Fixed summary step crashing ([#25](https://github.com/KIT-IAI/pywatts-pipeline/issues/25))
+  * Pipeline result and step buffer are reset after training ([#25](https://github.com/KIT-IAI/pywatts-pipeline/issues/25))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,5 @@
 
   * Fixed pipeline path is none error ([#16](https://github.com/KIT-IAI/pywatts-pipeline/issues/16))
   * Fixed summary step crashing ([#25](https://github.com/KIT-IAI/pywatts-pipeline/issues/25))
-  * Pipeline result and step buffer are reset after training ([#25](https://github.com/KIT-IAI/pywatts-pipeline/issues/25))
+  * Pipeline result and step buffer are reset after training ([#35](https://github.com/KIT-IAI/pywatts-pipeline/issues/35))
 

--- a/pywatts_pipeline/core/pipeline.py
+++ b/pywatts_pipeline/core/pipeline.py
@@ -177,7 +177,6 @@ class Pipeline(BaseTransformer):
         data: Union[pd.DataFrame, xr.Dataset],
         summary: bool = True,
         summary_formatter: SummaryFormatter = SummaryMarkdown(),
-        reset=True,
     ):
         """
         Executes all modules in the pipeline in the correct order. This method calls fit and transform on each module
@@ -193,9 +192,16 @@ class Pipeline(BaseTransformer):
         :return: The result of all end points of the pipeline
         :rtype: Dict[xr.DataArray]
         """
-        return self._run(
-            data, ComputationMode.FitTransform, summary, summary_formatter, reset=reset
+        result = self._run(
+            data, ComputationMode.FitTransform, summary, summary_formatter, reset=True
         )
+        self.reset()
+        return result
+
+    def reset(self):
+        for step in self.steps:
+            self.result = {}
+            step.reset()
 
     def _run(
         self,
@@ -208,9 +214,7 @@ class Pipeline(BaseTransformer):
     ):
 
         if reset:
-            for step in self.steps:
-                self.result = {}
-                step.reset()
+            self.reset()
 
         self.current_run_setting = RunSetting(
             computation_mode=mode,

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -220,8 +220,6 @@ class TestPipeline(unittest.TestCase):
         self.pipeline.train(pd.DataFrame({"test": [24, 24], "target": [12, 24]}, index=pd.to_datetime(
             ['2015-06-03 00:00:00', '2015-06-03 01:00:00'])), summary_formatter=summary_formatter_mock)
 
-        for step in self.pipeline.steps:
-            assert step.current_run_setting.computation_mode == ComputationMode.FitTransform
         create_summary_mock.assert_called_once_with(summary_formatter_mock)
 
     @patch('pywatts_pipeline.core.pipeline.FileManager')
@@ -470,6 +468,8 @@ class TestPipeline(unittest.TestCase):
                             index=pd.DatetimeIndex(pd.date_range('2000-01-01', freq='24H', periods=5)))
         result, summary = self.pipeline.train(data, summary=True)
 
+        self.assertEqual(self.pipeline.result, {})
+
         first_step.set_run_setting.assert_called_once()
         self.assertEqual(first_step.set_run_setting.call_args[0][0].computation_mode, ComputationMode.FitTransform)
         second_step.set_run_setting.assert_called_once()
@@ -477,9 +477,9 @@ class TestPipeline(unittest.TestCase):
 
         first_step.get_result.assert_called_once_with(None, return_all=True)
         second_step.get_result.assert_called_once_with(None, return_all=True)
+        self.assertEqual(first_step.reset.call_count, 2)
+        self.assertEqual(second_step.reset.call_count, 2)
 
-        first_step.reset.assert_called_once()
-        second_step.reset.assert_called_once()
         xr.testing.assert_equal(result["second"], da)
 
     @patch('pywatts_pipeline.core.pipeline.FileManager')


### PR DESCRIPTION
The pipeline's result and the buffer of all steps should be resetted after training to avoid strange behaviour when testing.

## Description

## Related Issues
closes #35 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos)
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Did you update the CHANGELOG

## PR review
Anyone in the community is free to review the PR once the tests have passed.

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones to the PR so it can be classified
